### PR TITLE
fix(ci): repair sync-amendments workflow and create missing script

### DIFF
--- a/.github/workflows/sync-amendments.yml
+++ b/.github/workflows/sync-amendments.yml
@@ -38,10 +38,8 @@ jobs:
 
       # Start a local rippled node so we can query which amendments the
       # pinned Docker image (xrpllabsofficial/xrpld:latest) supports.
-      # The node --local --persist --detach command blocks until rippled
-      # is accepting connections, then exits 0.
       - name: Start local rippled
-        run: npx tsx src/cli.ts node --local --persist --detach
+        run: npx tsx src/cli.ts start --detach
         timeout-minutes: 5
 
       # The faucet container starts after rippled; wait for its health endpoint
@@ -60,6 +58,10 @@ jobs:
         env:
           MAINNET_WS: wss://xrplcluster.com
           LOCAL_WS: ws://localhost:6006
+
+      - name: Stop local sandbox
+        if: always()
+        run: npx tsx src/cli.ts stop
 
       - name: Check for changes
         id: diff
@@ -101,25 +103,31 @@ jobs:
             exit 0
           fi
 
+          PR_BODY=$(cat <<'BODY'
+          ## Summary
+
+          Automated monthly sync of the `[amendments]` genesis list in `src/core/compose.ts`.
+
+          - **Source:** mainnet via `feature` RPC (`wss://xrplcluster.com`)
+          - **Filter:** amendments enabled on mainnet AND supported by `xrpllabsofficial/xrpld:latest`
+          - **New entries:** __NEW_COUNT__
+
+          Amendments that are enabled on mainnet but _not yet supported_ by the local rippled binary are listed in the workflow log and skipped — they will appear automatically on the next run after the Docker image is upgraded.
+
+          ## Review checklist
+
+          - [ ] Cross-check each new hash against [XRPL Known Amendments](https://xrpl.org/resources/known-amendments) or the rippled changelog
+          - [ ] Confirm the amendment name in the diff matches the hash (names in the RPC response can alias; hash is canonical)
+          - [ ] Start a fresh local node (`xrpl-up reset && xrpl-up start`) and verify `xrpl-up amendment list` shows all new amendments as enabled
+          - [ ] Run `npm run test:e2e:local` to confirm the sandbox starts cleanly with the updated genesis list
+
+          > Do not auto-merge. Human review required before this lands in `main`.
+          BODY
+          )
+          PR_BODY="${PR_BODY//__NEW_COUNT__/$NEW_COUNT}"
+
           gh pr create \
             --title "chore: sync [amendments] genesis list from mainnet (${DATE})" \
             --base main \
             --head "$BRANCH" \
-            --body "## Summary
-
-Automated monthly sync of the \`[amendments]\` genesis list in \`src/core/compose.ts\`.
-
-- **Source:** mainnet via \`feature\` RPC (\`wss://xrplcluster.com\`)
-- **Filter:** amendments enabled on mainnet AND supported by \`xrpllabsofficial/xrpld:latest\`
-- **New entries:** ${NEW_COUNT}
-
-Amendments that are enabled on mainnet but _not yet supported_ by the local rippled binary are listed in the workflow log and skipped — they will appear automatically on the next run after the Docker image is upgraded.
-
-## Review checklist
-
-- [ ] Cross-check each new hash against [XRPL Known Amendments](https://xrpl.org/resources/known-amendments) or the rippled changelog
-- [ ] Confirm the amendment name in the diff matches the hash (names in the RPC response can alias; hash is canonical)
-- [ ] Start a fresh local node (\`xrpl-up reset && xrpl-up node\`) and verify \`xrpl-up amendment list\` shows all new amendments as enabled
-- [ ] Run \`npm run test:e2e:local\` to confirm the sandbox starts cleanly with the updated genesis list
-
-> ⚠️ Do not auto-merge. Human review required before this lands in \`main\`."
+            --body "$PR_BODY"

--- a/scripts/update-genesis-amendments.ts
+++ b/scripts/update-genesis-amendments.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env npx tsx
+/**
+ * update-genesis-amendments.ts
+ *
+ * Queries mainnet for all enabled amendments, queries the local rippled for
+ * supported amendments, and appends any new (enabled on mainnet AND supported
+ * locally) amendments to the [amendments] block in src/core/compose.ts.
+ *
+ * Environment variables:
+ *   MAINNET_WS  — mainnet WebSocket URL  (default: wss://xrplcluster.com)
+ *   LOCAL_WS    — local rippled URL       (default: ws://localhost:6006)
+ *
+ * Exit codes:
+ *   0 — success (changes may or may not have been made; git diff decides)
+ *   1 — fatal error
+ */
+
+import { Client } from 'xrpl';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAINNET_WS = process.env.MAINNET_WS ?? 'wss://xrplcluster.com';
+const LOCAL_WS   = process.env.LOCAL_WS   ?? 'ws://localhost:6006';
+const COMPOSE_TS = path.resolve(__dirname, '../src/core/compose.ts');
+
+interface FeatureInfo {
+  name?: string;
+  enabled: boolean;
+  supported: boolean;
+}
+
+async function fetchFeatures(url: string): Promise<Record<string, FeatureInfo>> {
+  const client = new Client(url, { timeout: 60_000 });
+  await client.connect();
+  try {
+    const resp = await client.request({ command: 'feature' } as any);
+    return (resp.result as any).features as Record<string, FeatureInfo>;
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function main() {
+  console.log(`Fetching amendments from mainnet (${MAINNET_WS})...`);
+  const mainnetFeatures = await fetchFeatures(MAINNET_WS);
+
+  console.log(`Fetching amendments from local rippled (${LOCAL_WS})...`);
+  const localFeatures = await fetchFeatures(LOCAL_WS);
+
+  // Amendments enabled on mainnet
+  const enabledOnMainnet = Object.entries(mainnetFeatures)
+    .filter(([, info]) => info.enabled)
+    .map(([hash, info]) => ({ hash, name: info.name ?? hash }));
+
+  console.log(`Mainnet: ${enabledOnMainnet.length} enabled amendments`);
+
+  // Read existing compose.ts and extract current hashes
+  const composeSrc = fs.readFileSync(COMPOSE_TS, 'utf-8');
+  const existingHashes = new Set<string>();
+  for (const match of composeSrc.matchAll(/^([0-9A-F]{64})\s+\S+/gm)) {
+    existingHashes.add(match[1]);
+  }
+  console.log(`compose.ts: ${existingHashes.size} existing amendment entries`);
+
+  // Find new amendments: enabled on mainnet, supported by local, not already listed
+  const newAmendments: { hash: string; name: string }[] = [];
+  const unsupported: string[] = [];
+
+  for (const { hash, name } of enabledOnMainnet) {
+    if (existingHashes.has(hash)) continue;
+    const local = localFeatures[hash];
+    if (local?.supported) {
+      newAmendments.push({ hash, name });
+    } else {
+      unsupported.push(`${name} (${hash.slice(0, 12)}...)`);
+    }
+  }
+
+  if (unsupported.length > 0) {
+    console.log(`\nSkipped ${unsupported.length} amendments (enabled on mainnet but not supported by local rippled):`);
+    for (const s of unsupported) console.log(`  - ${s}`);
+  }
+
+  if (newAmendments.length === 0) {
+    console.log('\nNo new amendments to add. compose.ts is up to date.');
+    return;
+  }
+
+  // Sort by name for readability
+  newAmendments.sort((a, b) => a.name.localeCompare(b.name));
+
+  console.log(`\nAdding ${newAmendments.length} new amendments:`);
+  for (const { hash, name } of newAmendments) {
+    console.log(`  + ${hash} ${name}`);
+  }
+
+  // Insert new entries before the "# sync:end" marker
+  const newLines = newAmendments.map(({ hash, name }) => `${hash} ${name}`).join('\n');
+  const updated = composeSrc.replace('# sync:end', `${newLines}\n# sync:end`);
+
+  fs.writeFileSync(COMPOSE_TS, updated, 'utf-8');
+  console.log(`\nWrote ${newAmendments.length} new entries to ${COMPOSE_TS}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The `sync-amendments.yml` workflow has been broken since creation:
- **YAML syntax error on line 110** — multi-line `--body` content dropped to zero indentation, breaking the YAML literal block
- **Dead CLI commands** — `node --local --persist --detach` no longer exists (now `start --detach`)
- **Missing script** — `scripts/update-genesis-amendments.ts` was never created

This PR fixes all three:

- Fix YAML by using a heredoc (`<<'BODY'`) for the PR body, avoiding shell/YAML escaping issues
- Replace `node --local --persist --detach` with `start --detach`
- Add `stop` cleanup step with `if: always()` so Docker containers don't leak
- Create `scripts/update-genesis-amendments.ts` which:
  1. Connects to mainnet (`wss://xrplcluster.com`) and calls `feature` RPC for all enabled amendments
  2. Connects to local rippled (`ws://localhost:6006`) and calls `feature` RPC for supported amendments
  3. Filters to amendments enabled on mainnet AND supported locally
  4. Appends new entries to the `[amendments]` block in `src/core/compose.ts` before `# sync:end`
  5. Logs skipped amendments (enabled on mainnet but not supported by local binary)

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` and verify it runs without YAML errors
- [ ] Verify the script connects to mainnet and local rippled successfully
- [ ] Confirm no new amendments are appended (list should already be current)
- [ ] Force-test by temporarily removing an amendment from compose.ts, running the workflow, and verifying it gets re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)