### PR TITLE
fix(IS-22124): prevent secrets from appearing in shell history and ps output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,10 +170,12 @@ program
   .description('Fund an account using the faucet')
   .option('--network <network>', 'Network: local | testnet | devnet — omit for local')
   .option('--local', '[deprecated] Alias for --network local')
-  .option('-s, --seed <seed>', 'Wallet seed to fund (omit to generate a new wallet)')
+  .option('-s, --seed <seed>', 'Wallet seed to fund (insecure, prefer $WALLET_SEED env var; omit to generate a new wallet)')
   .action((opts: { network?: string; local?: boolean; seed?: string }) => {
     const network = opts.local ? 'local' : (opts.network ?? 'local');
-    faucetCommand({ network, seed: opts.seed }).catch(handleError);
+    const seed = opts.seed ?? process.env['WALLET_SEED'];
+    if (opts.seed) process.stderr.write('Warning: passing seed via flag is insecure. Use $WALLET_SEED env var instead.\n');
+    faucetCommand({ network, seed }).catch(handleError);
   });
 
 // ── run ───────────────────────────────────────────────────────────────────────

--- a/src/cli/commands/wallet/import.ts
+++ b/src/cli/commands/wallet/import.ts
@@ -7,7 +7,7 @@ import type { ECDSA } from "xrpl";
 import { ed25519 } from "@noble/curves/ed25519";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { encryptKeystore, getKeystoreDir, type KeystoreFile } from "../../utils/keystore";
-import { promptPassword } from "../../utils/prompt";
+import { promptPassword, resolveSecret } from "../../utils/prompt";
 
 type KeyType = "ed25519" | "secp256k1";
 
@@ -125,28 +125,30 @@ interface ImportOptions {
 export const importCommand = new Command("import")
   .alias("i")
   .description("Import key material into encrypted keystore")
-  .argument("<key-material>", "Seed, mnemonic, or private key to import (use '-' to read from stdin)")
+  .argument("[key-material]", "Seed, mnemonic, or private key to import (use '-' to read from stdin, or set WALLET_KEY env var)")
   .option("--key-type <type>", "Key algorithm: secp256k1 or ed25519 (required for unprefixed hex private keys)")
-  .option("--password <password>", "Encryption password (insecure, prefer interactive prompt)")
+  .option("--password <password>", "Encryption password (insecure, prefer $WALLET_PASSWORD env var or interactive prompt)")
   .option(
     "--keystore <dir>",
     "Keystore directory (default: ~/.xrpl/keystore/; XRPL_KEYSTORE env var also accepted)"
   )
   .option("--force", "Overwrite existing keystore entry", false)
   .option("--alias <name>", "Set a human-readable alias for this wallet at import time")
-  .action(async (keyMaterial: string, options: ImportOptions) => {
-    let input = keyMaterial;
-    if (keyMaterial === "-") {
+  .action(async (keyMaterial: string | undefined, options: ImportOptions) => {
+    // Resolve key material: flag → env var → stdin pipe → interactive prompt
+    let input: string;
+    if (keyMaterial !== undefined && keyMaterial !== "-") {
+      process.stderr.write("Warning: passing key material via argument is insecure. Use $WALLET_KEY env var or '-' to read from stdin.\n");
+      input = keyMaterial;
+    } else if (keyMaterial === "-") {
       input = readFileSync("/dev/stdin", "utf-8").trim();
+    } else if (process.env["WALLET_KEY"]) {
+      input = process.env["WALLET_KEY"];
+    } else {
+      input = await promptPassword("Key material (seed/mnemonic/private key): ");
     }
 
-    let password: string;
-    if (options.password !== undefined) {
-      process.stderr.write("Warning: passing passwords via flag is insecure\n");
-      password = options.password;
-    } else {
-      password = await promptPassword();
-    }
+    const password = await resolveSecret(options.password, "WALLET_PASSWORD", "Password: ");
 
     const keyMaterialType = detectKeyMaterialType(input);
 

--- a/src/cli/commands/wallet/new.ts
+++ b/src/cli/commands/wallet/new.ts
@@ -4,7 +4,7 @@ import type { ECDSA } from "xrpl";
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { encryptKeystore, getKeystoreDir, type KeystoreFile } from "../../utils/keystore";
-import { promptPasswordWithConfirmation } from "../../utils/prompt";
+import { promptPasswordWithConfirmation, resolveSecret } from "../../utils/prompt";
 
 type KeyType = "ed25519" | "secp256k1";
 
@@ -51,10 +51,12 @@ async function saveToKeystore(
 ): Promise<string> {
   let password: string;
   if (options.password !== undefined) {
-    process.stderr.write("Warning: passing passwords via flag is insecure\n");
+    process.stderr.write("Warning: passing passwords via flag is insecure. Use $WALLET_PASSWORD env var instead.\n");
     password = options.password;
+  } else if (process.env["WALLET_PASSWORD"]) {
+    password = process.env["WALLET_PASSWORD"];
   } else if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    process.stderr.write("Error: --password is required when --save is used in non-interactive mode\n");
+    process.stderr.write("Error: --password or $WALLET_PASSWORD is required when --save is used in non-interactive mode\n");
     process.exit(1);
   } else {
     password = await promptPasswordWithConfirmation();
@@ -87,7 +89,7 @@ export const newWalletCommand = new Command("new")
   .option("--json", "Output as JSON", false)
   .option("--save", "Encrypt and save the wallet to the keystore", false)
   .option("--show-secret", "Show the seed and private key (hidden by default)", false)
-  .option("--password <password>", "Encryption password for --save (insecure, prefer interactive prompt)")
+  .option("--password <password>", "Encryption password for --save (insecure, prefer $WALLET_PASSWORD env var or interactive prompt)")
   .option("--alias <name>", "Set a human-readable alias when saving to keystore")
   .option(
     "--keystore <dir>",

--- a/src/cli/commands/wallet/private-key.ts
+++ b/src/cli/commands/wallet/private-key.ts
@@ -23,8 +23,8 @@ function toAlgorithm(keyType: KeyType): ECDSA {
 export const privateKeyCommand = new Command("private-key")
   .alias("pk")
   .description("Derive private key from seed or mnemonic")
-  .option("--seed <seed>", "Family seed (sXXX...)")
-  .option("--mnemonic <phrase>", "BIP39 mnemonic phrase")
+  .option("--seed <seed>", "Family seed (insecure, prefer $WALLET_SEED env var)")
+  .option("--mnemonic <phrase>", "BIP39 mnemonic phrase (insecure, prefer $WALLET_MNEMONIC env var)")
   .option("--key-type <type>", "Key algorithm: secp256k1 or ed25519")
   .option(
     "--derivation-path <path>",
@@ -33,30 +33,33 @@ export const privateKeyCommand = new Command("private-key")
   )
   .option("--json", "Output as JSON", false)
   .action((options: PrivateKeyOptions) => {
-    const provided = [options.seed, options.mnemonic].filter(
-      (v) => v !== undefined
-    );
+    const effectiveSeed = options.seed ?? process.env["WALLET_SEED"];
+    const effectiveMnemonic = options.mnemonic ?? process.env["WALLET_MNEMONIC"];
+
+    const provided = [effectiveSeed, effectiveMnemonic].filter(Boolean);
 
     if (provided.length === 0) {
       process.stderr.write(
-        "Error: one of --seed or --mnemonic is required\n"
+        "Error: one of --seed, --mnemonic, $WALLET_SEED, or $WALLET_MNEMONIC is required\n"
       );
       process.exit(1);
     }
 
     if (provided.length > 1) {
       process.stderr.write(
-        "Error: only one of --seed or --mnemonic may be provided\n"
+        "Error: only one of --seed or --mnemonic may be provided (including env vars)\n"
       );
       process.exit(1);
     }
 
+    if (options.seed) process.stderr.write("Warning: passing seed via flag is insecure. Use $WALLET_SEED env var instead.\n");
+    if (options.mnemonic) process.stderr.write("Warning: passing mnemonic via flag is insecure. Use $WALLET_MNEMONIC env var instead.\n");
+
     let privateKey: string;
     let keyType: KeyType;
 
-    if (options.seed !== undefined) {
-      // Use ripple-keypairs directly so algorithm is inferred from seed encoding
-      const keypair = deriveKeypair(options.seed);
+    if (effectiveSeed !== undefined) {
+      const keypair = deriveKeypair(effectiveSeed);
       privateKey = keypair.privateKey;
       keyType =
         options.keyType ??
@@ -64,7 +67,7 @@ export const privateKeyCommand = new Command("private-key")
     } else {
       // mnemonic path
       keyType = options.keyType ?? "ed25519";
-      const wallet = Wallet.fromMnemonic(options.mnemonic!, {
+      const wallet = Wallet.fromMnemonic(effectiveMnemonic!, {
         mnemonicEncoding: "bip39",
         derivationPath: options.derivationPath,
         algorithm: toAlgorithm(keyType),

--- a/src/cli/commands/wallet/sign.ts
+++ b/src/cli/commands/wallet/sign.ts
@@ -6,7 +6,7 @@ import { sign as rippleSign, deriveKeypair } from "ripple-keypairs";
 import { Wallet } from "xrpl";
 import type { ECDSA } from "xrpl";
 import { decryptKeystore, type KeystoreFile } from "../../utils/keystore";
-import { promptPassword } from "../../utils/prompt";
+import { promptPassword, resolveSecret } from "../../utils/prompt";
 
 type KeyType = "ed25519" | "secp256k1";
 
@@ -100,11 +100,11 @@ export const signCommand = new Command("sign")
   .option("--message <string>", "UTF-8 message to sign (use --from-hex for hex-encoded)")
   .option("--from-hex", "Treat --message value as already hex-encoded", false)
   .option("--tx <json-or-path>", "Transaction JSON (inline or file path) to sign")
-  .option("--seed <seed>", "Family seed for signing")
-  .option("--mnemonic <phrase>", "BIP39 mnemonic for signing")
-  .option("--account <address>", "Account address to load from keystore (requires --password)")
+  .option("--seed <seed>", "Family seed for signing (insecure, prefer $WALLET_SEED env var)")
+  .option("--mnemonic <phrase>", "BIP39 mnemonic for signing (insecure, prefer $WALLET_MNEMONIC env var)")
+  .option("--account <address>", "Account address to load from keystore (requires --password or $WALLET_PASSWORD)")
   .option("--key-type <type>", "Key algorithm: secp256k1 or ed25519 (used with --seed or --mnemonic)")
-  .option("--password <password>", "Keystore decryption password (insecure, prefer interactive prompt)")
+  .option("--password <password>", "Keystore decryption password (insecure, prefer $WALLET_PASSWORD env var or interactive prompt)")
   .option(
     "--keystore <dir>",
     "Keystore directory (default: ~/.xrpl/keystore/; XRPL_KEYSTORE env var also accepted)"
@@ -116,23 +116,32 @@ export const signCommand = new Command("sign")
       process.exit(1);
     }
 
-    const keyMaterialCount = [options.seed, options.mnemonic, options.account].filter(Boolean).length;
+    const keyMaterialCount = [
+      options.seed ?? process.env["WALLET_SEED"],
+      options.mnemonic ?? process.env["WALLET_MNEMONIC"],
+      options.account,
+    ].filter(Boolean).length;
     if (keyMaterialCount === 0) {
-      process.stderr.write("Error: provide key material via --seed, --mnemonic, or --account\n");
+      process.stderr.write("Error: provide key material via --seed, --mnemonic, --account, $WALLET_SEED, or $WALLET_MNEMONIC\n");
       process.exit(1);
     }
     if (keyMaterialCount > 1) {
-      process.stderr.write("Error: provide only one of --seed, --mnemonic, or --account\n");
+      process.stderr.write("Error: provide only one of --seed, --mnemonic, or --account (including env vars)\n");
       process.exit(1);
     }
 
     let signerWallet: Wallet;
 
-    if (options.seed) {
-      signerWallet = walletFromSeed(options.seed);
-    } else if (options.mnemonic) {
+    const effectiveSeed = options.seed ?? process.env["WALLET_SEED"];
+    const effectiveMnemonic = options.mnemonic ?? process.env["WALLET_MNEMONIC"];
+
+    if (effectiveSeed) {
+      if (options.seed) process.stderr.write("Warning: passing seed via flag is insecure. Use $WALLET_SEED env var instead.\n");
+      signerWallet = walletFromSeed(effectiveSeed);
+    } else if (effectiveMnemonic) {
+      if (options.mnemonic) process.stderr.write("Warning: passing mnemonic via flag is insecure. Use $WALLET_MNEMONIC env var instead.\n");
       const keyType: KeyType = (options.keyType as KeyType) ?? "ed25519";
-      signerWallet = walletFromMnemonic(options.mnemonic, keyType);
+      signerWallet = walletFromMnemonic(effectiveMnemonic, keyType);
     } else {
       // --account: load from keystore
       const keystoreDir = getKeystoreDir(options);
@@ -151,13 +160,7 @@ export const signCommand = new Command("sign")
         process.exit(1);
       }
 
-      let password: string;
-      if (options.password !== undefined) {
-        process.stderr.write("Warning: passing passwords via flag is insecure\n");
-        password = options.password;
-      } else {
-        password = await promptPassword();
-      }
+      const password = await resolveSecret(options.password, "WALLET_PASSWORD", "Password: ");
 
       let material: string;
       try {

--- a/src/cli/utils/prompt.ts
+++ b/src/cli/utils/prompt.ts
@@ -1,5 +1,31 @@
 import { createInterface } from "readline";
 
+/**
+ * Resolve a sensitive value from (in priority order):
+ *   1. The CLI flag value (if provided — warns user it's insecure)
+ *   2. An environment variable (safe — doesn't appear in ps output)
+ *   3. An interactive masked prompt (TTY only)
+ *
+ * @param flagValue  Value from the CLI flag (undefined if not passed)
+ * @param envVar     Name of the environment variable to check (e.g. "WALLET_PASSWORD")
+ * @param promptText Prompt text for interactive mode
+ */
+export async function resolveSecret(
+  flagValue: string | undefined,
+  envVar: string,
+  promptText: string
+): Promise<string> {
+  if (flagValue !== undefined) {
+    process.stderr.write(`Warning: passing ${promptText.toLowerCase().replace(": ", "")} via flag is insecure. Use $${envVar} env var instead.\n`);
+    return flagValue;
+  }
+  const envValue = process.env[envVar];
+  if (envValue !== undefined && envValue !== "") {
+    return envValue;
+  }
+  return promptPassword(promptText);
+}
+
 export async function promptPassword(prompt = "Password: "): Promise<string> {
   if (process.stdin.isTTY) {
     return new Promise((resolve) => {

--- a/tests/e2e/wallet/import.test.ts
+++ b/tests/e2e/wallet/import.test.ts
@@ -22,7 +22,8 @@ describe("wallet import", () => {
         "--password", "testpassword",
         "--keystore", tmpDir,
       ]);
-      expect(importResult.stderr).toContain("Warning: passing passwords via flag is insecure");
+      expect(importResult.stderr).toContain("Warning: passing key material via argument is insecure");
+      expect(importResult.stderr).toContain("Warning: passing password via flag is insecure");
       expect(importResult.status).toBe(0);
       expect(importResult.stdout).toContain(`Imported account ${address}`);
 

--- a/tests/e2e/wallet/new.test.ts
+++ b/tests/e2e/wallet/new.test.ts
@@ -128,7 +128,7 @@ describe("wallet new", () => {
     try {
       const result = runCLI(["wallet", "new", "--save", "--keystore", tmpDir]);
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain("--password is required");
+      expect(result.stderr).toContain("--password or $WALLET_PASSWORD is required");
     } finally {
       rmSync(tmpDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

Fixes IS-22124. Seeds, mnemonics, private keys and passwords passed as CLI flags are visible in `ps aux`, shell history, and `/proc/<pid>/cmdline`. This PR adds environment variable alternatives and interactive prompts for all affected commands.

## Priority chain (per flag)

1. CLI flag — still supported for backwards compatibility, now warns it's insecure
2. Environment variable — safe, doesn't appear in `ps` output or history
3. Interactive masked prompt — TTY only, fallback when neither flag nor env var is set

## Env vars added

| Command | Flag | Env var |
|---|---|---|
| `wallet import` | `<key-material>` | `WALLET_KEY` |
| `wallet import` | `--password` | `WALLET_PASSWORD` |
| `wallet new` | `--password` | `WALLET_PASSWORD` |
| `wallet sign` | `--seed` | `WALLET_SEED` |
| `wallet sign` | `--mnemonic` | `WALLET_MNEMONIC` |
| `wallet sign` | `--password` | `WALLET_PASSWORD` |
| `wallet private-key` | `--seed` | `WALLET_SEED` |
| `wallet private-key` | `--mnemonic` | `WALLET_MNEMONIC` |
| `faucet` | `--seed` | `WALLET_SEED` |

## Usage example (CI/CD)

```bash
# Safe — seed never appears in process list or history
export WALLET_SEED=sEdAlice...
export WALLET_PASSWORD=my-keystore-pass

xrpl-up wallet import --alias alice
xrpl-up --node testnet payment --to rBob... --amount 10
```

## Test plan

- [ ] `wallet import $WALLET_KEY` — imports without flag
- [ ] `wallet import` with no arg and no env — prompts interactively
- [ ] `wallet new --save` with `$WALLET_PASSWORD` — no flag needed
- [ ] `wallet sign` with `$WALLET_SEED` — no flag needed
- [ ] `wallet private-key` with `$WALLET_MNEMONIC` — no flag needed
- [ ] `faucet` with `$WALLET_SEED` — funds existing wallet without flag
- [ ] All existing flag usages still work (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)