### PR TITLE
fix(IS-22127): enforce AES-GCM auth tag length of 16 bytes

### DIFF
--- a/src/utils/keystore.ts
+++ b/src/utils/keystore.ts
@@ -91,7 +91,11 @@ export function decryptKeystore(file: KeystoreFile, password: string): string {
     file.kdfparams.digest
   );
 
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  if (tag.length !== 16) {
+    throw new Error("Invalid authentication tag length");
+  }
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
   decipher.setAuthTag(tag);
 
   try {

--- a/tests/unit/keystore.test.ts
+++ b/tests/unit/keystore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { encryptKeystore, decryptKeystore, type KeystoreFile } from "../../src/utils/keystore";
+
+describe("keystore encrypt/decrypt", () => {
+  const seed = "sEdTnmue6JkroDsJRjHJbA29ytue5Yo";
+  const password = "test-password-123";
+  const address = "rTestAddress123456789012345";
+
+  it("round-trips correctly", () => {
+    const encrypted = encryptKeystore(seed, password, "ed25519", address);
+    const decrypted = decryptKeystore(encrypted, password);
+    expect(decrypted).toBe(seed);
+  });
+
+  it("fails with wrong password", () => {
+    const encrypted = encryptKeystore(seed, password, "ed25519", address);
+    expect(() => decryptKeystore(encrypted, "wrong-password")).toThrow("wrong password or corrupt keystore");
+  });
+
+  it("rejects truncated auth tag (IS-22127)", () => {
+    const encrypted = encryptKeystore(seed, password, "ed25519", address);
+    // Truncate the 32-char hex tag (16 bytes) to 16-char hex (8 bytes)
+    const tampered: KeystoreFile = {
+      ...encrypted,
+      cipherparams: {
+        ...encrypted.cipherparams,
+        tag: encrypted.cipherparams.tag.slice(0, 16),
+      },
+    };
+    expect(() => decryptKeystore(tampered, password)).toThrow("Invalid authentication tag length");
+  });
+
+  it("rejects empty auth tag", () => {
+    const encrypted = encryptKeystore(seed, password, "ed25519", address);
+    const tampered: KeystoreFile = {
+      ...encrypted,
+      cipherparams: {
+        ...encrypted.cipherparams,
+        tag: "",
+      },
+    };
+    expect(() => decryptKeystore(tampered, password)).toThrow("Invalid authentication tag length");
+  });
+
+  it("preserves label when provided", () => {
+    const encrypted = encryptKeystore(seed, password, "ed25519", address, "my-wallet");
+    expect(encrypted.label).toBe("my-wallet");
+    const decrypted = decryptKeystore(encrypted, password);
+    expect(decrypted).toBe(seed);
+  });
+});


### PR DESCRIPTION
## Summary

- Validate `tag.length === 16` before decryption — rejects truncated authentication tags that would be easier to forge
- Pass `{ authTagLength: 16 }` to `createDecipheriv` to enforce full 128-bit GCM tag

## Changes

- **`src/utils/keystore.ts`** — two additions in `decryptKeystore()`, per reviewer's fix
- **`tests/unit/keystore.test.ts`** — new unit tests: round-trip, wrong password, truncated tag, empty tag, label preservation

## Test plan

- [x] `npx vitest run tests/unit/keystore.test.ts` — 5/5 pass
- [ ] Existing e2e tests (wallet import/decrypt/sign) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)