### PR TITLE
test: extend snapshot validation poll to 120s for Node 22 CI

### DIFF
--- a/tests/e2e/sandbox/snapshot.test.ts
+++ b/tests/e2e/sandbox/snapshot.test.ts
@@ -201,9 +201,9 @@ describe("snapshot rollback", () => {
 
   it("wait for account B to be validated", async () => {
     // After snapshot save resumes the sandbox, consensus needs time to
-    // re-establish and produce validated ledgers. On CI (2 vCPU) this
-    // can take 30-40s. Use 60s timeout.
-    for (let i = 0; i < 30; i++) {
+    // re-establish and produce validated ledgers. On CI (2 vCPU) with
+    // Node 22 this can take 60-90s. Use 120s timeout.
+    for (let i = 0; i < 60; i++) {
       const result = runXrplUp(
         ["accounts", "--local", "--address", postSnapshotAddress],
         {},
@@ -212,7 +212,7 @@ describe("snapshot rollback", () => {
       if (result.status === 0) return;
       await new Promise(r => setTimeout(r, 2000));
     }
-    throw new Error(`Account B (${postSnapshotAddress}) not validated after 60s`);
+    throw new Error(`Account B (${postSnapshotAddress}) not validated after 120s`);
   });
 
   it("restore snapshot (rolls back to pre-B state)", () => {


### PR DESCRIPTION
Node 22 takes longer to re-establish consensus after snapshot save than Node 20/24, causing the 60s poll to time out. Increase retries from 30 to 60 (120s ceiling) to cover the slower runtime.