### PR TITLE
docs: update README to reflect npm package availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ CLI for XRPL local development and scripting. Spin up a local sandbox with pre-f
 
 ## Installation
 
-~~**From npm (global):**~~
+**From npm (global):**
 
-~~`npm install -g xrpl-up`~~
-
-_Not available yet: package has not been published to npm._
+```bash
+npm install -g xrpl-up
+```
 
 **From source (development):**
 
@@ -24,6 +24,30 @@ npm install
 npm run build
 npm link
 ```
+
+## Claude Code Plugin
+
+xrpl-up includes a [Claude Code](https://claude.ai/code) plugin that lets an AI agent translate natural language into CLI commands.
+
+**Install the plugin:**
+
+```bash
+# Add the marketplace (one-time)
+claude plugin marketplace add ripple/xrpl-up
+
+# Install the plugin
+claude plugin install xrpl-up@xrpl-up --scope user
+```
+
+**Usage:** In a Claude Code session, type:
+
+```
+/xrpl-up:xrpl-up fund a new wallet on testnet
+/xrpl-up:xrpl-up show balance for rAddress...
+/xrpl-up:xrpl-up start local sandbox
+```
+
+Or invoke `/xrpl-up:xrpl-up` without arguments and describe what you want to do.
 
 ## Quick Start
 
@@ -1085,7 +1109,7 @@ xrpl-up amendment enable PermissionedDomains --local --auto-reset
 
 Scaffolds a new project with config, TypeScript setup, and example scripts. Prompts for a default network; choose `local` for local-sandbox-ready scripts out of the box.
 
-> **Prerequisite:** `xrpl-up` must be available on PATH. Until the package is published to npm, install from source with `npm link` (see [Installation](#installation)). The generated `package.json` scripts (`npm run start`, `npm run accounts`) call `xrpl-up` from PATH and do not re-install it locally.
+> **Prerequisite:** `xrpl-up` must be available on PATH. Install globally via `npm install -g xrpl-up` or from source with `npm link` (see [Installation](#installation)). The generated `package.json` scripts (`npm run start`, `npm run accounts`) call `xrpl-up` from PATH and do not re-install it locally.
 
 ```bash
 xrpl-up init

--- a/tests/e2e/sandbox/snapshot.test.ts
+++ b/tests/e2e/sandbox/snapshot.test.ts
@@ -201,9 +201,9 @@ describe("snapshot rollback", () => {
 
   it("wait for account B to be validated", async () => {
     // After snapshot save resumes the sandbox, consensus needs time to
-    // re-establish and produce validated ledgers. On CI (2 vCPU) this
-    // can take 30-40s. Use 60s timeout.
-    for (let i = 0; i < 30; i++) {
+    // re-establish and produce validated ledgers. On CI (2 vCPU) with
+    // Node 22 this can take 60-90s. Use 120s timeout.
+    for (let i = 0; i < 60; i++) {
       const result = runXrplUp(
         ["accounts", "--local", "--address", postSnapshotAddress],
         {},
@@ -212,7 +212,7 @@ describe("snapshot rollback", () => {
       if (result.status === 0) return;
       await new Promise(r => setTimeout(r, 2000));
     }
-    throw new Error(`Account B (${postSnapshotAddress}) not validated after 60s`);
+    throw new Error(`Account B (${postSnapshotAddress}) not validated after 120s`);
   });
 
   it("restore snapshot (rolls back to pre-B state)", () => {

--- a/xrpl-up-problem-space.md
+++ b/xrpl-up-problem-space.md
@@ -6,11 +6,11 @@ XRPL Local Development Sandbox — what it solves today and what it could solve 
 
 ## Problem Statement
 
-- XRPL developer always complain about there is no unified sandbox workflow for rapid prototyping and repeatable testing.
-- Community feedback repeatedly highlights unreliable/inconsistent test environments and outdated onboarding experience.
+- There is no unified sandbox workflow for rapid prototyping and repeatable testing.
+- Community feedback highlights unreliable/inconsistent test environments.
 - Public Testnet/Devnet introduce resets, downtime, and rate limits that reduce confidence in test repeatability.
-- Direct standalone `rippled` setup is operationally heavy (config, funding, lifecycle, resets), so app teams spend time on infrastructure mechanics instead of product logic.
-- Teams need a practical way to run local `rippled` on modest hardware (without full network sync/consensus overhead) so development is feasible on typical laptops and CI runners.
+- Direct standalone `xrpld` setup is operationally heavy (config, funding, lifecycle, resets), so app teams spend time on infrastructure mechanics instead of product logic.
+- Teams need a practical way to run local `xrpld` on modest hardware (without full network sync/consensus overhead) so development is feasible on typical laptops and CI runners.
 - Stateful AMM/orderbook scenarios require repeated setup and manual rollback, which slows iteration and increases flakiness in both local and CI runs.
 
 ## Executive Summary
@@ -38,11 +38,11 @@ Target feature set (roadmap):
 
 ### Experiments Completed (Decided to Drop as Product Directions)
 
-- **Fork and Replay experiments were completed and then dropped as product directions:** `xrpl-up node --local --fork` can mirror XRP balances into local state, but XRPL does not expose private keys, so mirrored accounts cannot sign and are only passive recipients. Replay was also tested by re-submitting historical mainnet blobs, but those blobs carry original sequence/signature context and fail locally (`terPRE_SEQ`) when state differs. Native `rippled --replay` additionally requires full historical state on disk, which is impractical for ephemeral developer containers.
+- **Fork and Replay experiments were completed and then dropped as product directions:** `xrpl-up node --local --fork` can mirror XRP balances into local state, but XRPL does not expose private keys, so mirrored accounts cannot sign and are only passive recipients. Replay was also tested by re-submitting historical mainnet blobs, but those blobs carry original sequence/signature context and fail locally (`terPRE_SEQ`) when state differs. Native `xrpld --replay` additionally requires full historical state on disk, which is impractical for ephemeral developer containers.
 
 ## Immediate Feature Set
 
-`xrpl-up` runs in two modes. **Local mode (`--local`)** starts a standalone rippled node in
+`xrpl-up` runs in two modes. **Local mode (`--local`)** starts a standalone xrpld node in
 Docker with deterministic ledger control and local faucet funding. **Remote mode**
 (`--network testnet | devnet`) connects to public XRPL endpoints over WebSocket
 without starting local infrastructure.
@@ -52,11 +52,11 @@ without starting local infrastructure.
 `xrpl-up` has two intentional command sets:
 
 - **Sandbox operation commands:** lifecycle, state, and environment control for local and remote developer workflows.
-- **rippled API wrapper commands:** convenience wrappers for common transactions and demos (`amm`, `nft`, `channel`, `mpt`).
+- **xrpld API wrapper commands:** convenience wrappers for common transactions and demos (`amm`, `nft`, `channel`, `mpt`).
 
 Wrapper commands are intentionally non-exhaustive. They are optimized for demonstration,
 onboarding, and quick experimentation. For complex or production-grade flows, developers
-should use `xrpl.js` directly or call `rippled` RPC endpoints.
+should use `xrpl.js` directly or call `xrpld` RPC endpoints.
 
 ### Command × Network Scope
 
@@ -65,19 +65,19 @@ should use `xrpl.js` directly or call `rippled` RPC endpoints.
 | Sandbox operation | `node` | Start/connect to a sandbox session and provision baseline accounts | ✅ | ✅ |
 | Sandbox operation | `run` | Execute scripts against the selected network with injected connection env vars | ✅ | ✅ |
 | Sandbox operation | `accounts` | Show funded accounts and live balances from the account store | ✅ | ✅ |
-| Sandbox operation | `status` | Show network health (ledger index, rippled version, faucet availability) | ✅ | ✅ |
+| Sandbox operation | `status` | Show network health (ledger index, xrpld version, faucet availability) | ✅ | ✅ |
 | Sandbox operation | `faucet` | Fund a new or existing account and persist it to the account store | ✅ | ✅ |
-| Sandbox operation | `logs` | Stream local Docker service logs (`rippled`/`faucet`) | ✅ | ❌ |
+| Sandbox operation | `logs` | Stream local Docker service logs (`xrpld`/`faucet`) | ✅ | ❌ |
 | Sandbox operation | `stop` | Stop the local Docker sandbox stack | ✅ | ❌ |
 | Sandbox operation | `reset` | Wipe local containers, ledger volume, and account store | ✅ | ❌ |
 | Sandbox operation | `snapshot` | Save/restore/list local ledger + account checkpoints | ✅ | ❌ |
-| Sandbox operation | `config` | Validate/manage local rippled configuration | ✅ | ❌ |
+| Sandbox operation | `config` | Validate/manage local xrpld configuration | ✅ | ❌ |
 | Sandbox operation | `init` | Scaffold a starter project with scripts/tests/templates | n/a | n/a |
-| rippled API wrapper | `amm create` | Create an AMM pool with issuer/trust-line setup automation | ✅ | ✅ |
-| rippled API wrapper | `amm info` | Inspect AMM pool state and key trading parameters | ✅ | ✅ |
-| rippled API wrapper | `nft` | Convenience NFT lifecycle flows (mint/list/offers/sell/accept/burn) | ✅ | ✅ |
-| rippled API wrapper | `channel` | Convenience payment-channel flows (create/fund/sign/verify/claim/list) | ✅ | ✅ |
-| rippled API wrapper | `mpt` | Convenience MPT issuance flows (create/info/authorize/set/destroy) | ✅ | ✅ |
+| xrpld API wrapper | `amm create` | Create an AMM pool with issuer/trust-line setup automation | ✅ | ✅ |
+| xrpld API wrapper | `amm info` | Inspect AMM pool state and key trading parameters | ✅ | ✅ |
+| xrpld API wrapper | `nft` | Convenience NFT lifecycle flows (mint/list/offers/sell/accept/burn) | ✅ | ✅ |
+| xrpld API wrapper | `channel` | Convenience payment-channel flows (create/fund/sign/verify/claim/list) | ✅ | ✅ |
+| xrpld API wrapper | `mpt` | Convenience MPT issuance flows (create/info/authorize/set/destroy) | ✅ | ✅ |
 
 ### Example Workflow
 
@@ -90,22 +90,22 @@ should use `xrpl.js` directly or call `rippled` RPC endpoints.
 
 ### Feature Breakdown
 
-Starting a rippled node in standalone mode involves Docker configuration, rippled.cfg tuning,
+Starting a xrpld node in standalone mode involves Docker configuration, xrpld.cfg tuning,
 port mapping, and health checking. `xrpl-up` wraps all of this in a single command.
 
 **Hardware requirements for local mode:** Docker Desktop, ~2 GB RAM, ~500 MB disk for the
 Docker image, ~50–500 MB for ledger data. No internet after initial pull. Standalone mode
-needs far less than a full rippled node — no peers, no consensus, no historical sync.
+needs far less than a full xrpld node — no peers, no consensus, no historical sync.
 
 ```
 xrpl-up node --local
 ```
 
-- Starts rippled in Docker (standalone mode, no peers, no sync)
-- Generates a valid `rippled.cfg` automatically
+- Starts xrpld in Docker (standalone mode, no peers, no sync)
+- Generates a valid `xrpld.cfg` automatically
 - Waits for the node to be healthy before returning
 - `--persist` to keep ledger state across restarts
-- `--debug` for rippled debug logging
+- `--debug` for xrpld debug logging
 
 #### Pre-funded Test Accounts
 
@@ -113,7 +113,7 @@ In a fresh standalone node, only the genesis account exists with 100 billion XRP
 automatically creates and funds test accounts so developers can start writing transactions
 immediately.
 
-- Faucet server runs inside Docker alongside rippled
+- Faucet server runs inside Docker alongside xrpld
 - Each account funded with 1,000 XRP from the genesis wallet
 - Account seeds/addresses printed to terminal and persisted to `~/.xrpl-up/{network}-accounts.json`
 - `xrpl-up faucet --network local|testnet|devnet` also appends to the same store, so all funded accounts appear in `xrpl-up accounts` regardless of how they were created
@@ -121,7 +121,7 @@ immediately.
 
 #### Auto-advancing Ledger
 
-Standalone rippled does not close ledgers automatically. `xrpl-up` auto-advances the ledger
+Standalone xrpld does not close ledgers automatically. `xrpl-up` auto-advances the ledger
 on a configurable interval so submitted transactions confirm without manual intervention.
 
 - Default: closes a ledger every 1,000 ms
@@ -131,7 +131,7 @@ on a configurable interval so submitted transactions confirm without manual inte
 #### Named Network Support
 
 In remote mode, `xrpl-up` connects to a public XRPL node over WebSocket — no Docker, no
-local rippled. Named networks are URL aliases:
+local xrpld. Named networks are URL aliases:
 
 | Network | WebSocket URL |
 |---------|---------------|
@@ -157,9 +157,9 @@ injected as environment variables. TypeScript is run directly via `tsx` — no b
 #### Live Status & Logs
 
 ```
-xrpl-up status    # ledger index, rippled version, faucet health
+xrpl-up status    # ledger index, xrpld version, faucet health
 xrpl-up accounts  # all funded accounts and their live balances
-xrpl-up logs      # streams Docker Compose logs for rippled and faucet
+xrpl-up logs      # streams Docker Compose logs for xrpld and faucet
 ```
 
 #### Project Scaffolding
@@ -264,7 +264,7 @@ xrpl-up reset --snapshots  # also delete all saved snapshots
 
 ### Amendment Control
 
-The local node starts with rippled's default amendment set, which may not match current
+The local node starts with xrpld's default amendment set, which may not match current
 mainnet. A `temDISABLED` error locally means the amendment isn't active.
 
 - Fetch live mainnet amendment set at startup for automatic parity
@@ -292,7 +292,7 @@ xrpl-up test
 ### Hooks Development Environment
 
 XRPL Hooks are WebAssembly smart contracts. Developing hooks requires a hooks-enabled
-rippled build, separate from the mainline binary.
+xrpld build, separate from the mainline binary.
 
 - Auto-detect if a script deploys a Hook and switch to the hooks-enabled Docker image
 - `--hooks` flag to start the node with hooks amendment enabled
@@ -307,10 +307,10 @@ xrpl-up inspect --ledger N --network mainnet
 Fetches ledger N, decodes all transactions, displays accounts/amounts/results. No
 re-execution — pure display of what happened on mainnet.
 
-### Core Developer Feature Set (for `rippled` protocol development)
+### Core Developer Feature Set (for `xrpld` protocol development)
 
 The sections above focus on XRPL app developers. This track is for core developers working
-on consensus, networking, and amendment behavior inside `rippled`.
+on consensus, networking, and amendment behavior inside `xrpld`.
 
 Phase 1 — Private multi-node network:
 


### PR DESCRIPTION
Remove strikethrough and "not available yet" notice from installation section. Update init prerequisite note to reference npm install.