### PR TITLE
docs: add beta-experimental npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ CLI for XRPL local development and scripting. Spin up a local sandbox with pre-f
 **From npm (global):**
 
 ```bash
+# Latest stable release
 npm install -g xrpl-up
+
+# Beta release
+npm install -g xrpl-up@beta-experimental
 ```
 
 **From source (development):**


### PR DESCRIPTION
## Summary
- `npm install -g xrpl-up` only resolves the `latest` dist-tag — beta releases are published under `beta-experimental`
- Adds the beta install command so users can opt in to pre-releases

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)