### PR TITLE
feat: pin rippled image to 3.1.3 and auto-bump via watch workflow

### DIFF
--- a/.github/workflows/watch-rippled-image.yml
+++ b/.github/workflows/watch-rippled-image.yml
@@ -159,3 +159,105 @@ jobs:
             git commit -m "chore: update known rippled image digests [skip ci]"
             git push
           fi
+
+  # ── 4. Bump DEFAULT_IMAGE in compose.ts and open a PR ─────────────────────
+  bump-default-image:
+    name: Bump pinned rippled image
+    needs: [detect, e2e]
+    if: |
+      needs.e2e.result == 'success' &&
+      github.event_name != 'workflow_dispatch' &&
+      contains(fromJson(needs.detect.outputs.images), 'xrpllabsofficial/xrpld:latest')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          VERSION=$(grep "DEFAULT_IMAGE" src/core/compose.ts \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current pinned: ${VERSION}"
+
+      - name: Get version tag matching latest digest
+        id: latest
+        run: |
+          LATEST_DIGEST=$(curl -sf \
+            "https://hub.docker.com/v2/repositories/xrpllabsofficial/xrpld/tags/latest" \
+            | jq -r '.digest')
+          # Find the highest semver tag whose digest matches latest
+          MATCHING_TAG=$(curl -sf \
+            "https://hub.docker.com/v2/repositories/xrpllabsofficial/xrpld/tags?page_size=50" \
+            | jq -r --arg d "$LATEST_DIGEST" \
+              '[.results[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | select(.digest == $d) | .name] | sort_by(split(".") | map(tonumber)) | last // empty')
+          echo "version=${MATCHING_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version tag for latest: ${MATCHING_TAG}"
+
+      - name: Check if bump needed
+        id: diff
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          LATEST="${{ steps.latest.outputs.version }}"
+          if [ -z "$LATEST" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No version tag found matching latest digest — skipping."
+          elif [ "$CURRENT" = "$LATEST" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Already pinned to ${CURRENT} — nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Will bump ${CURRENT} → ${LATEST}"
+          fi
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          LATEST="${{ steps.latest.outputs.version }}"
+          BRANCH="chore/bump-rippled-${LATEST}"
+
+          sed -i "s|xrpllabsofficial/xrpld:[0-9]*\.[0-9]*\.[0-9]*|xrpllabsofficial/xrpld:${LATEST}|g" \
+            src/core/compose.ts
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/core/compose.ts
+          git commit -m "chore: bump rippled image ${CURRENT} → ${LATEST}"
+          git push --force origin "$BRANCH"
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #${EXISTING} already open — skipping."
+            exit 0
+          fi
+
+          PR_BODY=$(mktemp)
+          {
+            echo "## Summary"
+            echo ""
+            echo "Bumps the pinned rippled image from \`xrpllabsofficial/xrpld:${CURRENT}\` to \`xrpllabsofficial/xrpld:${LATEST}\`."
+            echo ""
+            echo "## Tests"
+            echo ""
+            echo "The full \`test:e2e:local\` suite passed against \`xrpllabsofficial/xrpld:latest\` (which resolves to \`${LATEST}\`) before this PR was opened."
+            echo ""
+            echo "## Review checklist"
+            echo ""
+            echo "- [ ] Check the [rippled ${LATEST} release notes](https://github.com/XRPLF/rippled/releases/tag/${LATEST}) for breaking changes or new amendments"
+            echo "- [ ] Verify no new amendments need to be added to \`NOT_ON_MAINNET\` in the amendment test"
+            echo ""
+            echo "> ⚠️ Do not auto-merge. Human review required before this lands in \`main\`."
+          } > "$PR_BODY"
+
+          gh pr create \
+            --title "chore: bump rippled image ${CURRENT} → ${LATEST}" \
+            --base main \
+            --head "$BRANCH" \
+            --body-file "$PR_BODY"

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -9,7 +9,7 @@ export const LOCAL_WS_PORT = 6006;
 export const FAUCET_PORT = 3001;
 export const LOCAL_WS_URL = `ws://localhost:${LOCAL_WS_PORT}`;
 export const FAUCET_URL = `http://localhost:${FAUCET_PORT}`;
-export const DEFAULT_IMAGE = 'xrpllabsofficial/xrpld:latest';
+export const DEFAULT_IMAGE = 'xrpllabsofficial/xrpld:3.1.3';
 
 const XRPL_UP_DIR = path.join(os.homedir(), '.xrpl-up');
 const COMPOSE_FILE = path.join(XRPL_UP_DIR, 'docker-compose.yml');


### PR DESCRIPTION
## Summary

- Pins `DEFAULT_IMAGE` from `:latest` to `:3.1.3` for reproducibility — avoids surprise failures when Docker Hub updates `latest`
- Adds a `bump-default-image` job to the existing `watch-rippled-image.yml`: after e2e tests pass against a new `xrpllabsofficial/xrpld:latest` digest, it resolves the matching version tag and opens a PR to update `DEFAULT_IMAGE` in `compose.ts`

## How the auto-bump works

1. Daily cron detects a new digest on `xrpllabsofficial/xrpld:latest`
2. e2e suite runs against the new image across all modes and Node versions
3. If all tests pass, the new job queries Docker Hub to find the semver tag matching that digest
4. Opens a PR bumping `DEFAULT_IMAGE` — human reviews before merge

## Review checklist

- [ ] Verify `DEFAULT_IMAGE = 'xrpllabsofficial/xrpld:3.1.3'` in `src/core/compose.ts`
- [ ] Review the new `bump-default-image` job in `watch-rippled-image.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)