### PR TITLE
Fix outdated/fictional command syntax in example docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Step-by-step walkthroughs for common XRPL use cases using `xrpl-up` CLI commands.
 
-Each guide starts a local sandbox (`xrpl-up node`) and walks through a complete workflow — fund accounts, run transactions, inspect results.
+Each guide starts a local sandbox (`xrpl-up start --detach`) and walks through a complete workflow — fund accounts, run transactions, inspect results.
 
 ---
 
@@ -13,7 +13,7 @@ Each guide starts a local sandbox (`xrpl-up node`) and walks through a complete 
 git clone https://github.com/ripple/xrpl-up.git
 cd xrpl-up && npm install && npm run build && npm link
 
-xrpl-up node          # start local XRPL sandbox
+xrpl-up start --detach          # start local XRPL sandbox
 xrpl-up status        # confirm healthy
 ```
 

--- a/examples/advanced/amm-dex-arbitrage.md
+++ b/examples/advanced/amm-dex-arbitrage.md
@@ -13,7 +13,7 @@ This guide:
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -22,16 +22,24 @@ export XRPL_NODE=local
 
 ## Step 1: Create the AMM pool
 
-```bash
-# XRP/USD pool: 100 XRP, 100 USD → implicit price 1 XRP = 1 USD
-xrpl-up amm create XRP USD --amount1 100 --amount2 100 --fee 0.3
-# ✔ AMM pool created
-#   XRP reserve  100
-#   USD reserve  100
-#   fee          0.3%
-#   issuer       rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
+`amm create` doesn't create issuers or fund the LP for you — set that up first (see [amm.md](../simple/amm.md) for the full walkthrough):
 
+```bash
+xrpl-up faucet --network local   # → ISSUER_SEED / ISSUER
+xrpl-up faucet --network local   # → LP_SEED / LP
+ISSUER_SEED=sEdIssuerSeedXXX
 ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
+LP_SEED=sEdLpSeedXXX
+LP=rLpXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+xrpl-up account set --set-flag defaultRipple --seed $ISSUER_SEED
+xrpl-up trust set --currency USD --issuer $ISSUER --limit 50000 --seed $LP_SEED
+xrpl-up payment --to $LP --amount 100/USD/$ISSUER --seed $ISSUER_SEED
+
+# XRP/USD pool: 100 XRP, 100 USD → implicit price 1 XRP = 1 USD; 0.3% fee (300 = 0.3% in basis-points-of-a-percent)
+xrpl-up amm create --asset XRP --asset2 USD/$ISSUER \
+  --amount 100000000 --amount2 100 --trading-fee 300 \
+  --seed $LP_SEED
 ```
 
 ---
@@ -39,9 +47,9 @@ ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## Step 2: Check the initial AMM price
 
 ```bash
-xrpl-up amm info XRP USD.$ISSUER
-# XRP reserve   100 XRP
-# USD reserve   100 USD
+xrpl-up amm info --asset XRP --asset2 USD/$ISSUER
+# Asset 1: 100 XRP
+# Asset 2: 100 USD
 # → implicit price: 1 XRP = 1 USD
 ```
 
@@ -52,14 +60,15 @@ xrpl-up amm info XRP USD.$ISSUER
 Fund a market maker and post an offer at **1 XRP = 1.25 USD** (i.e., selling USD cheaply compared to the AMM):
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdMMSeedXXX  address: rMMXXX
 
 MM_SEED=sEdMMSeedXXXXXXXXXXXXXXXXXXXXXXXX
 MM=rMMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# MM needs a USD trust line
+# MM needs a USD trust line and an actual USD balance to sell
 xrpl-up trust set --currency USD --issuer $ISSUER --limit 50000 --seed $MM_SEED
+xrpl-up payment --to $MM --amount 50/USD/$ISSUER --seed $ISSUER_SEED
 
 # MM places an offer: pay 25 USD, get 20 XRP (= 1.25 USD per XRP)
 # i.e. MM is willing to sell USD at a 25% premium over AMM price
@@ -77,7 +86,7 @@ xrpl-up offer create --taker-pays 25/USD/$ISSUER --taker-gets 20 --seed $MM_SEED
 **AMM quote** — inspect the pool state to estimate the swap output:
 
 ```bash
-xrpl-up amm info XRP USD.$ISSUER
+xrpl-up amm info --asset XRP --asset2 USD/$ISSUER
 # XRP reserve   100 XRP
 # USD reserve   100 USD
 # fee           0.3%
@@ -106,16 +115,17 @@ xrpl-up account offers $MM
 
 ## Step 5: Execute the arbitrage — buy XRP from AMM
 
-Fund an arbitrageur with USD (they set a trust line and receive USD from the MM first):
+Fund an arbitrageur with USD (they set a trust line and need an actual USD balance to pay with):
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdArbitragerSeedXXX  address: rArbitragerXXX
 
 ARB_SEED=sEdArbitragerSeedXXXXXXXXXXXXXXXX
 ARB=rArbitragerXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 xrpl-up trust set --currency USD --issuer $ISSUER --limit 50000 --seed $ARB_SEED
+xrpl-up payment --to $ARB --amount 20/USD/$ISSUER --seed $ISSUER_SEED
 ```
 
 Place an IOC offer to buy XRP by paying USD — the ledger routes through the cheapest source (AMM first):
@@ -156,7 +166,7 @@ xrpl-up offer create --taker-pays 20 --taker-gets 25/USD/$ISSUER --seed $ARB_SEE
 #   Profit ~8.23 USD
 
 # Check the AMM pool — it shifted toward the DEX price
-xrpl-up amm info XRP USD.$ISSUER
+xrpl-up amm info --asset XRP --asset2 USD/$ISSUER
 # XRP reserve   80 XRP   ← decreased (sold 20 XRP to arb)
 # USD reserve  125 USD   ← increased (received ~16.77 USD from arb)
 # → new price: 125/80 = 1.5625 USD/XRP  (moved toward DEX price of 1.25)

--- a/examples/advanced/channel-settlement.md
+++ b/examples/advanced/channel-settlement.md
@@ -9,7 +9,7 @@ This guide goes beyond the quick-start [payment-channel.md](../simple/payment-ch
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -19,8 +19,8 @@ export XRPL_NODE=local
 ## Step 1: Create accounts
 
 ```bash
-xrpl-up faucet --local
-xrpl-up faucet --local
+xrpl-up faucet --network local
+xrpl-up faucet --network local
 xrpl-up accounts --local
 
 SENDER_SEED=sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX
@@ -62,22 +62,22 @@ xrpl-up channel list $SENDER
 
 The sender issues signed claims as service is delivered. Each claim covers the **cumulative total**:
 
+`channel sign` prints only the raw signature hex (no other fields) — get the channel's public key once via `channel list` (see Step 2):
+
 ```bash
+PUBKEY=ED1234XXXXXXXXXX   # from `xrpl-up channel list $SENDER`
+
 # After delivering unit 1 (worth 5 XRP):
-xrpl-up channel sign $CHANNEL_ID 5 --seed $SENDER_SEED
-# ✔ Claim signed (off-chain, no tx fee)
-#   amount     5 XRP
-#   signature  3045...XXXXXXXXXX
-#   publicKey  ED1234XXXXXXXXXX
+xrpl-up channel sign --channel $CHANNEL_ID --amount 5 --seed $SENDER_SEED
+# 3045...XXXXXXXXXX
 SIG_5=3045...XXXXXXXXXX
-PUBKEY=ED1234XXXXXXXXXX
 
 # After delivering unit 2 (cumulative: 12 XRP):
-xrpl-up channel sign $CHANNEL_ID 12 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 12 --seed $SENDER_SEED
 SIG_12=3045...YYYYYYYYYY
 
 # After delivering unit 3 (cumulative: 27 XRP):
-xrpl-up channel sign $CHANNEL_ID 27 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 27 --seed $SENDER_SEED
 SIG_27=3045...ZZZZZZZZZZ
 ```
 
@@ -86,7 +86,7 @@ SIG_27=3045...ZZZZZZZZZZ
 Verify a claim before accepting it:
 
 ```bash
-xrpl-up channel verify $CHANNEL_ID 27 $SIG_27 $PUBKEY
+xrpl-up channel verify --channel $CHANNEL_ID --amount 27 --signature $SIG_27 --public-key $PUBKEY
 # ✔ Claim signature valid
 ```
 
@@ -97,8 +97,8 @@ xrpl-up channel verify $CHANNEL_ID 27 $SIG_27 $PUBKEY
 The receiver decides to settle 27 XRP mid-session (e.g., end-of-day batch settlement). The channel stays open for more payments:
 
 ```bash
-xrpl-up channel claim $CHANNEL_ID \
-  --amount 27 --signature $SIG_27 --public-key $PUBKEY \
+xrpl-up channel claim --channel $CHANNEL_ID \
+  --amount 27 --balance 27 --signature $SIG_27 --public-key $PUBKEY \
   --seed $RECEIVER_SEED
 # ✔ Channel claim submitted
 #   redeemed  27 XRP  (channel balance: 27 XRP / 100 XRP)
@@ -120,11 +120,11 @@ The next batch of claims continues from the cumulative total (not from zero):
 
 ```bash
 # Cumulative total after continued service: 45 XRP
-xrpl-up channel sign $CHANNEL_ID 45 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 45 --seed $SENDER_SEED
 SIG_45=...
 
 # Cumulative total: 68 XRP
-xrpl-up channel sign $CHANNEL_ID 68 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 68 --seed $SENDER_SEED
 SIG_68=...
 ```
 
@@ -135,8 +135,8 @@ SIG_68=...
 Submit the latest claim (68 XRP cumulative). The channel pays out only the **delta** since last settlement (68 − 27 = 41 XRP):
 
 ```bash
-xrpl-up channel claim $CHANNEL_ID \
-  --amount 68 --signature $SIG_68 --public-key $PUBKEY \
+xrpl-up channel claim --channel $CHANNEL_ID \
+  --amount 68 --balance 68 --signature $SIG_68 --public-key $PUBKEY \
   --seed $RECEIVER_SEED
 # ✔ Channel claim submitted
 #   total claimed  68 XRP  (delta: 41 XRP this settlement)
@@ -152,7 +152,7 @@ xrpl-up channel claim $CHANNEL_ID \
 If the sender wants to extend the session beyond the original 100 XRP cap:
 
 ```bash
-xrpl-up channel fund $CHANNEL_ID 50 --seed $SENDER_SEED
+xrpl-up channel fund --channel $CHANNEL_ID --amount 50 --seed $SENDER_SEED
 # ✔ Channel funded  +50 XRP  (total: 150 XRP)
 
 xrpl-up channel list $SENDER
@@ -166,7 +166,7 @@ xrpl-up channel list $SENDER
 When the sender wants to stop the session, they request closure. The settle delay gives the receiver time to submit their final claim:
 
 ```bash
-xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $SENDER_SEED
 # ✔ Close requested
 # ⏳ Receiver has 600 s to submit final claim
 #    After that, sender can close and recover remaining XRP
@@ -179,11 +179,11 @@ xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
 The receiver still has claims in-hand (say, SIG_90 for 90 XRP cumulative). They submit the final settlement:
 
 ```bash
-xrpl-up channel sign $CHANNEL_ID 90 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 90 --seed $SENDER_SEED
 SIG_90=...
 
-xrpl-up channel claim $CHANNEL_ID \
-  --amount 90 --signature $SIG_90 --public-key $PUBKEY \
+xrpl-up channel claim --channel $CHANNEL_ID \
+  --amount 90 --balance 90 --signature $SIG_90 --public-key $PUBKEY \
   --close --seed $RECEIVER_SEED
 # ✔ Final settlement + channel closed
 #   total claimed  90 XRP  (delta: 22 XRP this settlement)
@@ -201,7 +201,7 @@ If the receiver does **not** submit within the settle delay after the sender req
 
 ```bash
 # After settle-delay expires (600 s in this example):
-xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $SENDER_SEED
 # ✔ Channel force-closed
 #   No pending receiver claim — all remaining XRP returned to sender
 ```

--- a/examples/advanced/escrow-crypto-condition.md
+++ b/examples/advanced/escrow-crypto-condition.md
@@ -13,7 +13,7 @@ This guide covers:
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 
@@ -60,10 +60,10 @@ CONDITION=A0258020...XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## Step 2: Create accounts
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderSeedXXX  address: rSenderXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdReceiverSeedXXX  address: rReceiverXXX
 
 SENDER_SEED=sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX

--- a/examples/advanced/mpt-policy-lifecycle.md
+++ b/examples/advanced/mpt-policy-lifecycle.md
@@ -9,7 +9,7 @@ This guide complements [MPT](mpt.md) with a focus on the **policy controls** rat
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -32,16 +32,16 @@ All policy flags are **set at issuance creation and cannot be changed afterwards
 ## Step 1: Create issuer and holder accounts
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdIssuerSeedXXX  address: rIssuerXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderASeedXXX  address: rHolderAXXX   (will be approved)
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderBSeedXXX  address: rHolderBXXX   (will attempt to opt-in, then be rejected)
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderCSeedXXX  address: rHolderCXXX   (approved, then locked, then clawback)
 
 ISSUER_SEED=sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX

--- a/examples/advanced/multi-sig-tickets.md
+++ b/examples/advanced/multi-sig-tickets.md
@@ -9,7 +9,7 @@ Combine a **SignerList** (2-of-3 multi-signature) with **Tickets** (reserved seq
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -23,8 +23,8 @@ export XRPL_NODE=local
 The treasury account + three signers (Alice, Bob, Carol):
 
 ```bash
-xrpl-up faucet --local; xrpl-up faucet --local
-xrpl-up faucet --local; xrpl-up faucet --local
+xrpl-up faucet --network local; xrpl-up faucet --network local
+xrpl-up faucet --network local; xrpl-up faucet --network local
 # Run xrpl-up accounts --local to see all four:
 xrpl-up accounts --local
 ```
@@ -47,7 +47,8 @@ CAROL=rCarolXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ### 1b. Install a 2-of-3 signer list on the treasury
 
 ```bash
-xrpl-up accountset signer-list 2 "$ALICE:1,$BOB:1,$CAROL:1" \
+xrpl-up multisig set --quorum 2 \
+  --signer $ALICE:1 --signer $BOB:1 --signer $CAROL:1 \
   --seed $TREASURY_SEED
 # ✔ Signer list set  quorum 2  signers: rAliceXXX(1) rBobXXX(1) rCarolXXX(1)
 ```
@@ -84,7 +85,7 @@ Tickets let co-signers prepare transactions independently — no sequence depend
 # The treasury account reserves 3 tickets
 # (requires multi-sig now that master key is disabled — use a script for this
 #  or reserve tickets BEFORE disabling the master key)
-xrpl-up ticket create 3 --seed $TREASURY_SEED
+xrpl-up ticket create --count 3 --seed $TREASURY_SEED
 # ✔ 3 tickets created
 #   sequences: 10, 11, 12
 

--- a/examples/advanced/regulated-token.md
+++ b/examples/advanced/regulated-token.md
@@ -9,7 +9,7 @@ A fully-regulated IOU token flow where the issuer controls every step: only appr
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -35,7 +35,7 @@ Holder A (approved)        Holder B (rejected)
 ## Step 1: Create the regulated issuer account
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdIssuerSeedXXX  address: rIssuerXXX
 
 ISSUER_SEED=sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX
@@ -50,7 +50,7 @@ ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ```bash
 # Allow clawback of issued tokens (must come first, before any trust lines)
-xrpl-up account set --allow-clawback --seed $ISSUER_SEED
+xrpl-up account set --allow-clawback --confirm --seed $ISSUER_SEED
 # ✔ Flag set: allowClawback (permanent)
 
 # Require issuer approval for every trust line
@@ -81,10 +81,10 @@ xrpl-up account info $ISSUER
 ## Step 3: Create holder accounts
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderASeedXXX  address: rHolderAXXX   (will be approved)
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderBSeedXXX  address: rHolderBXXX   (will be rejected)
 
 HOLDER_A_SEED=sEdHolderASeedXXXXXXXXXXXXXXXXXX
@@ -113,7 +113,7 @@ xrpl-up trust set --currency USD --issuer $ISSUER --limit 10000 --seed $HOLDER_B
 
 ```bash
 # Approve Holder A's trust line
-xrpl-up trust set --currency USD --issuer $HOLDER_A --limit 0 --freeze --seed $ISSUER_SEED --authorize
+xrpl-up trust set --currency USD --issuer $HOLDER_A --limit 0 --auth --seed $ISSUER_SEED
 # ✔ Trust line authorized: USD / rHolderAXXX...
 
 # Holder B is NOT authorized — deliberately left pending
@@ -147,29 +147,8 @@ xrpl-up deposit-preauth list $ISSUER
 
 ## Step 7: Issue tokens to Holder A
 
-Use a script to send USD from the issuer to the approved holder (direct Payment):
-
-```typescript
-// scripts/issue-tokens.ts
-import { Client, Wallet } from 'xrpl';
-const client = new Client('ws://localhost:6006');
-await client.connect();
-const issuer = Wallet.fromSeed('sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX');
-const tx = {
-  TransactionType: 'Payment',
-  Account: issuer.address,
-  Destination: 'rHolderAXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-  Amount: { currency: 'USD', issuer: issuer.address, value: '1000' },
-};
-const prepared = await client.autofill(tx as any);
-const signed = issuer.sign(prepared as any);
-const result = await client.submitAndWait(signed.tx_blob);
-console.log(result.result.meta?.TransactionResult);
-await client.disconnect();
-```
-
 ```bash
-xrpl-up run scripts/issue-tokens.ts
+xrpl-up payment --to $HOLDER_A --amount 1000/USD/$ISSUER --seed $ISSUER_SEED
 # tesSUCCESS
 ```
 
@@ -237,7 +216,7 @@ xrpl-up account set --clear-flag depositAuth --seed $ISSUER_SEED
 
 | Scenario | Command |
 |----------|---------|
-| Approve a new holder | `trust set --currency USD --issuer $HOLDER --limit 0 --freeze --authorize --seed $ISSUER_SEED` |
+| Approve a new holder | `trust set --currency USD --issuer $HOLDER --limit 0 --auth --seed $ISSUER_SEED` |
 | Suspend a holder | `trust set --currency USD --issuer $HOLDER --limit 0 --freeze --seed $ISSUER_SEED` |
 | Reinstate a holder | `trust set --currency USD --issuer $HOLDER --limit 0 --unfreeze --seed $ISSUER_SEED` |
 | Freeze all holders (emergency) | `account set --set-flag globalFreeze --seed $ISSUER_SEED` |

--- a/examples/simple/amm.md
+++ b/examples/simple/amm.md
@@ -9,109 +9,83 @@ XRPL's built-in AMM (XLS-30) lets you provide liquidity to a constant-product po
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
 
 ---
 
-## 1. Create an XRP / USD pool
+## 1. Set up an issuer and fund the liquidity provider with USD
 
-`amm create` handles everything automatically: issuer creation, trust lines, token minting, and pool seeding.
-
-```bash
-# XRP / USD pool — 100 XRP and 100 USD, 0.5% trading fee
-xrpl-up amm create XRP USD
-# ✔ AMM pool created
-#   asset1   100 XRP
-#   asset2   100 USD  (issuer: rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX)
-#   fee      0.5%
-#   LP token rAMMXXXXX / LPToken
-#
-#   Hint: xrpl-up amm info XRP USD.rIssuerXXXXX
-```
-
-Save the issuer address printed in the output:
+`amm create` submits a single `AMMCreate` transaction — it does **not** create issuers, trust lines, or mint tokens for you. For an XRP/USD pool, the LP account needs a real USD balance first:
 
 ```bash
+# Fund an issuer and a liquidity-provider account
+xrpl-up faucet --network local   # → issuer seed/address
+xrpl-up faucet --network local   # → LP seed/address
+
+ISSUER_SEED=sEdIssuerSeedXXX
 ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
+LP_SEED=sEdLpSeedXXX
+LP=rLpXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Let the issuer's USD ripple through trust lines (needed for it to settle payments)
+xrpl-up account set --set-flag defaultRipple --seed $ISSUER_SEED --node local
+
+# LP trusts the issuer for USD, then the issuer sends USD to the LP
+xrpl-up trust set --currency USD --issuer $ISSUER --limit 10000 --seed $LP_SEED --node local
+xrpl-up payment --to $LP --amount 1000/USD/$ISSUER --seed $ISSUER_SEED --node local
 ```
 
 ---
 
-## 2. Inspect the pool
+## 2. Create an XRP / USD pool
 
 ```bash
-xrpl-up amm info XRP USD.$ISSUER
-# pool account   rAMMXXXXX...
-# XRP reserve    100 XRP
-# USD reserve    100 USD
-# LP supply      10.000000 LPToken
-# fee            0.5%
+# 100 XRP / 100 USD pool, 0.5% trading fee (amounts: XRP in drops, IOU as decimal)
+xrpl-up amm create --asset XRP --asset2 USD/$ISSUER \
+  --amount 100000000 --amount2 100 --trading-fee 500 \
+  --seed $LP_SEED --node local
 ```
 
 ---
 
-## 3. Custom amounts and fee
+## 3. Inspect the pool
 
 ```bash
-# 500 XRP / 1000 USD pool with a 0.3% fee
-xrpl-up amm create XRP USD --amount1 500 --amount2 1000 --fee 0.3
+xrpl-up amm info --asset XRP --asset2 USD/$ISSUER --node local
 ```
 
 ---
 
-## 4. Create a token/token pool
-
-```bash
-# USD / EUR pool (xrpl-up creates two separate issuers automatically)
-xrpl-up amm create USD EUR --amount1 100 --amount2 120
-# → USD issuer: rUsdIssuerXXXX
-# → EUR issuer: rEurIssuerXXXX
-```
-
----
-
-## 5. Trade against the pool
+## 4. Trade against the pool
 
 Once the pool is live, any account can trade against it using the DEX `offer create` command — the AMM is automatically matched as a counterparty.
 
 ```bash
-# Fund a trader
-xrpl-up faucet --local
-# → seed: sEdTraderSeedXXX  address: rTraderXXX
-
+# Fund a trader and give it a USD trust line
+xrpl-up faucet --network local
 TRADER_SEED=sEdTraderSeedXXX
 TRADER=rTraderXXX
+xrpl-up trust set --currency USD --issuer $ISSUER --limit 10000 --seed $TRADER_SEED --node local
 
-# Trader sets a trust line for USD
-xrpl-up trust set --currency USD --issuer $ISSUER --limit 10000 --seed $TRADER_SEED
-
-# Trader sells 5 XRP into the pool (gets USD back)
-xrpl-up offer create --taker-pays 5 --taker-gets 4/USD/$ISSUER --seed $TRADER_SEED \
+# Trader sells 5 XRP into the pool (gets USD back) — price includes the 0.5% fee + slippage
+xrpl-up offer create --taker-pays 4.5/USD/$ISSUER --taker-gets 5 --seed $TRADER_SEED --node local \
   --immediate-or-cancel
 # The AMM fills the offer at the current pool price
 ```
 
 ---
 
-## 6. Query the pool after a trade
+## 5. Query the pool after a trade
 
 After swaps the pool ratio shifts (and the price moves):
 
 ```bash
-xrpl-up amm info XRP USD.$ISSUER
-# XRP reserve    105 XRP   ← increased
-# USD reserve    95.238...  ← decreased
-```
-
----
-
-## 7. Look up a pool by AMM account address
-
-```bash
-xrpl-up amm info --account rAMMXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+xrpl-up amm info --asset XRP --asset2 USD/$ISSUER --node local
+# Asset 1: 104.735721 XRP   ← increased
+# Asset 2: 95.5 USD         ← decreased
 ```
 
 ---

--- a/examples/simple/checks.md
+++ b/examples/simple/checks.md
@@ -9,7 +9,7 @@ Checks work with both **XRP** and **IOUs**.
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -19,10 +19,10 @@ export XRPL_NODE=local
 ## 1. Set up sender and receiver
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderSeedXXX  address: rSenderXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdReceiverSeedXXX  address: rReceiverXXX
 
 SENDER_SEED=sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX
@@ -78,7 +78,7 @@ xrpl-up check list $RECEIVER
 The receiver cashes for exactly 5 XRP (less than the 10 XRP maximum):
 
 ```bash
-xrpl-up check cash $CHECK_ID --amount 5 --seed $RECEIVER_SEED
+xrpl-up check cash --check $CHECK_ID --amount 5 --seed $RECEIVER_SEED
 # ✔ Check cashed  received 5 XRP
 ```
 
@@ -89,7 +89,7 @@ xrpl-up check cash $CHECK_ID --amount 5 --seed $RECEIVER_SEED
 Instead of an exact amount, the receiver asks for "as much as possible, but at least 3 XRP":
 
 ```bash
-xrpl-up check cash $CHECK_ID --deliver-min 3 --seed $RECEIVER_SEED
+xrpl-up check cash --check $CHECK_ID --deliver-min 3 --seed $RECEIVER_SEED
 # ✔ Check cashed  received 10 XRP  (full sendMax)
 ```
 
@@ -103,11 +103,11 @@ Either the sender or the receiver can cancel at any time. After the expiry, anyo
 
 ```bash
 # Sender cancels their own check
-xrpl-up check cancel $CHECK_ID --seed $SENDER_SEED
+xrpl-up check cancel --check $CHECK_ID --seed $SENDER_SEED
 # ✔ Check cancelled  A1B2C3D4...
 
 # Receiver cancels (also valid)
-xrpl-up check cancel $CHECK_ID --seed $RECEIVER_SEED
+xrpl-up check cancel --check $CHECK_ID --seed $RECEIVER_SEED
 ```
 
 ---
@@ -122,7 +122,7 @@ xrpl-up check create --to $RECEIVER --send-max 5 --seed $SENDER_SEED --expiratio
 
 # Wait 10 seconds, then cancel (anyone can do this after expiry)
 sleep 10
-xrpl-up check cancel $EXPIRED_CHECK_ID --seed $SENDER_SEED
+xrpl-up check cancel --check $EXPIRED_CHECK_ID --seed $SENDER_SEED
 ```
 
 ---

--- a/examples/simple/clawback.md
+++ b/examples/simple/clawback.md
@@ -9,7 +9,7 @@ Both **IOU (trust line)** and **MPT** tokens support clawback.
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -24,14 +24,14 @@ export XRPL_NODE=local
 
 ```bash
 # Fund a brand-new issuer account
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdIssuerSeedXXX  address: rIssuerXXX
 
 ISSUER_SEED=sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX
 ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # Enable clawback BEFORE creating any trust lines
-xrpl-up account set --allow-clawback --seed $ISSUER_SEED
+xrpl-up account set --allow-clawback --confirm --seed $ISSUER_SEED
 # ✔ Flag set: allowClawback  (permanent)
 ```
 
@@ -48,7 +48,7 @@ xrpl-up account info $ISSUER
 
 ```bash
 # Fund a holder
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderSeedXXX  address: rHolderXXX
 
 HOLDER_SEED=sEdHolderSeedXXXXXXXXXXXXXXXXXXXXX
@@ -61,7 +61,7 @@ xrpl-up account set --set-flag defaultRipple --seed $ISSUER_SEED
 xrpl-up trust set --currency USD --issuer $ISSUER --limit 10000 --seed $HOLDER_SEED
 
 # Issue 500 USD to the holder
-# (use xrpl-up run with a Payment script, or via the DEX)
+xrpl-up payment --to $HOLDER --amount 500/USD/$ISSUER --seed $ISSUER_SEED
 ```
 
 ---
@@ -96,7 +96,7 @@ xrpl-up account trust-lines $HOLDER
 ### Step 1: Create an MPT issuance with clawback enabled
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdMptIssuerSeedXXX  address: rMptIssuerXXX
 
 MPT_ISSUER_SEED=sEdMptIssuerSeedXXXXXXXXXXXXXXX
@@ -116,7 +116,7 @@ MPT_ID=00070C4495F14B0EXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ### Step 2: Issue tokens to a holder
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdMptHolderSeedXXX  address: rMptHolderXXX
 
 MPT_HOLDER_SEED=sEdMptHolderSeedXXXXXXXXXXXXXXX

--- a/examples/simple/deposit-auth.md
+++ b/examples/simple/deposit-auth.md
@@ -7,7 +7,7 @@ When `DepositAuth` is enabled on an account, it blocks all incoming payments unl
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -18,21 +18,22 @@ export XRPL_NODE=local
 
 ```bash
 # The account that will require deposit authorization
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdReceiverSeedXXX  address: rReceiverXXX
 
 # An authorized sender
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderASeedXXX  address: rSenderAXXX
 
 # An unauthorized sender (for testing)
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderBSeedXXX  address: rSenderBXXX
 
 RECEIVER_SEED=sEdReceiverSeedXXXXXXXXXXXXXXXXX
 RECEIVER=rReceiverXXXXXXXXXXXXXXXXXXXXXXXXXXX
 SENDER_A_SEED=sEdSenderASeedXXXXXXXXXXXXXXXXX
 SENDER_A=rSenderAXXXXXXXXXXXXXXXXXXXXXXXXXXX
+SENDER_B_SEED=sEdSenderBSeedXXXXXXXXXXXXXXXXX
 SENDER_B=rSenderBXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
@@ -84,9 +85,11 @@ With Checks as a workaround (the receiver cashes the check — no deposit restri
 ```bash
 # Sender B creates a check (anyone can create a check to an account with depositAuth)
 xrpl-up check create --to $RECEIVER --send-max 5 --seed $SENDER_B_SEED
+# → CHECK_ID
+CHECK_ID=...
 
 # Receiver cashes the check (receiver initiates — not a direct payment, so depositAuth does not block it)
-xrpl-up check cash $CHECK_ID --amount 5 --seed $RECEIVER_SEED
+xrpl-up check cash --check $CHECK_ID --amount 5 --seed $RECEIVER_SEED
 ```
 
 > **Note:** DepositAuth blocks *incoming payments*, not *cashing checks* (which are receiver-initiated). Escrow finishes and channel claims are similarly receiver-initiated and bypass DepositAuth.

--- a/examples/simple/dex.md
+++ b/examples/simple/dex.md
@@ -7,7 +7,7 @@ XRPL has a fully on-chain order book built into the protocol. No smart contracts
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -20,13 +20,13 @@ We need a token to trade. Skip to step 2 if you already have an IOU set up.
 
 ```bash
 # Fund issuer and trader accounts
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdIssuerSeedXXX   address: rIssuerXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdTraderASeedXXX  address: rTraderAXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdTraderBSeedXXX  address: rTraderBXXX
 
 ISSUER_SEED=sEdIssuerSeedXXX
@@ -104,7 +104,7 @@ xrpl-up offer create --taker-pays 100/USD/$ISSUER --taker-gets 50 --seed $TRADER
 
 ```bash
 # Cancel Trader A's open offer by its sequence number
-xrpl-up offer cancel 7 --seed $TRADER_A_SEED
+xrpl-up offer cancel --sequence 7 --seed $TRADER_A_SEED
 # ✔ Offer 7 cancelled
 ```
 

--- a/examples/simple/escrow.md
+++ b/examples/simple/escrow.md
@@ -11,7 +11,7 @@ Two escrow types:
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -26,11 +26,11 @@ Fund a sender and create an escrow to a destination:
 
 ```bash
 # Fund sender
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderSeedXXX  address: rSenderXXX
 
 # Fund destination
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → address: rDestXXX
 
 SENDER_SEED=sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX

--- a/examples/simple/issued-token.md
+++ b/examples/simple/issued-token.md
@@ -7,7 +7,7 @@ XRPL's native support for custom currencies. An issuer account mints tokens; hol
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -18,12 +18,12 @@ export XRPL_NODE=local
 
 ```bash
 # Create the token issuer
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → address: rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # → seed:    sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX
 
 # Create a token holder
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → address: rHolderXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # → seed:    sEdHolderSeedXXXXXXXXXXXXXXXXXXXXX
 
@@ -62,12 +62,8 @@ xrpl-up trust set --currency USD --issuer $ISSUER_ADDR --limit 10000 --seed $HOL
 On XRPL, issuers create tokens simply by sending them to a trust-line holder. The issuer's "balance" is always the negative mirror of what it has issued.
 
 ```bash
-# Send 1000 USD to the holder (uses an offer or direct payment path)
-xrpl-up offer create --taker-pays 1000/USD/$ISSUER_ADDR --taker-gets 999 --seed $ISSUER_SEED
+xrpl-up payment --to $HOLDER_ADDR --amount 1000/USD/$ISSUER_ADDR --seed $ISSUER_SEED
 ```
-
-> **Simpler approach for testing:** Use `xrpl-up run` with a script that calls `client.autofill` on a Payment transaction directly.
-> See the generated `scripts/example-token.ts` from `xrpl-up init`.
 
 ---
 
@@ -123,7 +119,7 @@ xrpl-up account set --clear-flag globalFreeze --seed $ISSUER_SEED
 
 ```bash
 # On a fresh issuer account, before any holders exist:
-xrpl-up account set --allow-clawback --seed $FRESH_ISSUER_SEED
+xrpl-up account set --allow-clawback --confirm --seed $FRESH_ISSUER_SEED
 
 # Later, reclaim 10 USD from a holder:
 xrpl-up clawback --amount 10/USD/$HOLDER_ADDR --seed $ISSUER_SEED

--- a/examples/simple/mpt.md
+++ b/examples/simple/mpt.md
@@ -9,7 +9,7 @@ MPT is XRPL's next-generation fungible token standard. Unlike IOU trust lines, M
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -18,21 +18,21 @@ export XRPL_NODE=local
 
 ## 1. Create an MPT issuance
 
-Auto-fund a wallet and mint a new token:
+Fund an issuer account, then mint a new token:
 
 ```bash
-# Minimal — just a transferable token
-xrpl-up mptoken issuance create --flags can-transfer
-# ✔ MPT issuance created
-#   issuance ID  00070C4495F14B0EXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   issuer       rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   seed         sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX
-#
-#   Hint: xrpl-up mptoken authorize 00070C44... --seed <holder-seed>
+xrpl-up faucet --network local
+# → seed: sEdIssuerSeedXXX  address: rIssuerXXX
 
-MPT_ID=00070C4495F14B0EXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ISSUER_SEED=sEdIssuerSeedXXXXXXXXXXXXXXXXXXXXX
 ISSUER=rIssuerXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Minimal — just a transferable token
+xrpl-up mptoken issuance create --flags can-transfer --seed $ISSUER_SEED
+# ✔ MPT issuance created
+#   issuance ID  00070C4495F14B0EXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+MPT_ID=00070C4495F14B0EXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ### Full issuance with all controls
@@ -80,7 +80,7 @@ Before a holder can receive MPTs they must opt in by running `mptoken authorize`
 
 ```bash
 # Fund a holder wallet
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolderSeedXXX  address: rHolderXXX
 
 HOLDER_SEED=sEdHolderSeedXXXXXXXXXXXXXXXXXXXXX
@@ -137,7 +137,7 @@ xrpl-up account mptokens $HOLDER
 
 ```bash
 # Fund a second holder
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdHolder2SeedXXX  address: rHolder2XXX
 
 HOLDER2_SEED=sEdHolder2SeedXXXXXXXXXXXXXXXXXXXXX
@@ -203,12 +203,12 @@ xrpl-up mptoken issuance destroy $MPT_ID --seed $ISSUER_SEED
 ## Full lifecycle at a glance
 
 ```bash
-# 1. Create
-xrpl-up mptoken issuance create --flags can-transfer,can-clawback
-# → MPT_ID, ISSUER_SEED, ISSUER
+# 1. Create (issuer already funded via `xrpl-up faucet --network local`)
+xrpl-up mptoken issuance create --flags can-transfer,can-clawback --seed $ISSUER_SEED
+# → MPT_ID
 
 # 2. Holder opts in
-xrpl-up faucet --local    # → HOLDER, HOLDER_SEED
+xrpl-up faucet --network local    # → HOLDER, HOLDER_SEED
 xrpl-up mptoken authorize $MPT_ID --seed $HOLDER_SEED
 
 # 3. Send tokens

--- a/examples/simple/nft.md
+++ b/examples/simple/nft.md
@@ -7,7 +7,7 @@ Mint, sell, buy, and burn Non-Fungible Tokens on XRPL. XRPL NFTs (XLS-20) are na
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -16,28 +16,29 @@ export XRPL_NODE=local
 
 ## 1. Mint an NFT
 
-Auto-funds a new wallet and mints a transferable NFT with a metadata URI:
+Fund a minter account, then mint a transferable NFT with a metadata URI. `--transfer-fee` requires `--transferable`:
 
 ```bash
+xrpl-up faucet --network local
+# → seed: sEdMinterSeedXXX  address: rMinterXXX
+
+MINTER_SEED=sEdMinterSeedXXXXXXXXXXXXXXXXXXXXX
+MINTER=rMinterXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
 xrpl-up nft mint \
   --uri https://example.com/nft-metadata.json \
+  --transferable \
   --transfer-fee 500 \
-  --taxon 1
+  --taxon 1 \
+  --seed $MINTER_SEED
 # ✔ NFT minted
 #   NFTokenID  000800006B9C0BXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   issuer     rMinterXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   taxon      1
-#   fee        500 bps
-#
-#   Hint: xrpl-up nft offer create --nft 000800006B9C0B... --amount 5 --seed <seed>
 ```
 
-Save values:
+Save the NFTokenID:
 
 ```bash
 NFT_ID=000800006B9C0BXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-MINTER_SEED=sEdMinterSeedXXXXXXXXXXXXXXXXXXXXX
-MINTER=rMinterXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ### Mint flags
@@ -65,14 +66,13 @@ xrpl-up account nfts $MINTER
 
 ## 3. Create a sell offer
 
-The owner puts the NFT up for sale:
+The owner puts the NFT up for sale. `--sell` is required — without it, `nft offer create` makes a **buy** offer instead:
 
 ```bash
 # Sell for 5 XRP
-xrpl-up nft offer create --nft $NFT_ID --amount 5 --seed $MINTER_SEED
+xrpl-up nft offer create --nft $NFT_ID --amount 5 --sell --seed $MINTER_SEED
 # ✔ Sell offer created
 #   offerID  A1B2C3D4XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   price    5 XRP
 
 OFFER_ID=A1B2C3D4XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
@@ -81,7 +81,7 @@ Sell for an IOU instead:
 
 ```bash
 # Sell for 100 USD (requires buyer to have a USD trust line)
-xrpl-up nft offer create --nft $NFT_ID --amount 100/USD/$ISSUER --seed $MINTER_SEED
+xrpl-up nft offer create --nft $NFT_ID --amount 100/USD/$ISSUER --sell --seed $MINTER_SEED
 ```
 
 ---
@@ -98,24 +98,17 @@ xrpl-up nft offer list $NFT_ID
 
 ## 5. Buyer accepts the sell offer
 
-A different wallet accepts the offer and pays the price:
+Fund a separate buyer wallet, then accept the offer:
 
 ```bash
-# Auto-fund a buyer wallet and accept the offer
-xrpl-up nft offer accept --sell-offer $OFFER_ID
-# ✔ Offer accepted
-#   buyer    rBuyerXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   price    5 XRP
-#   royalty  0.25 XRP → rMinterXXX...
+xrpl-up faucet --network local
+# → seed: sEdBuyerSeedXXX  address: rBuyerXXX
 
 BUYER_SEED=sEdBuyerSeedXXXXXXXXXXXXXXXXXXXXX
 BUYER=rBuyerXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
 
-Provide a specific buyer seed:
-
-```bash
 xrpl-up nft offer accept --sell-offer $OFFER_ID --seed $BUYER_SEED
+# ✔ Offer accepted
 ```
 
 ---
@@ -134,14 +127,18 @@ xrpl-up account nfts $MINTER
 
 ## 7. Broker a trade (optional)
 
-A third party (broker) can match a sell offer and a buy offer simultaneously, taking a commission:
+A third party (broker) can match a sell offer and a buy offer simultaneously, taking a commission. `nft offer create` without `--sell` makes a buy offer instead — it needs `--owner` (the current NFT holder) since there's no NFT to transfer from the buyer's side yet:
 
 ```bash
-# Buyer creates a buy offer
-xrpl-up faucet --local
+# Buyer creates a buy offer for an NFT held by $MINTER
+xrpl-up faucet --network local
 # → seed: sEdBuyer2SeedXXX  address: rBuyer2XXX
 
-# (Create buy offer via xrpl-up run script — xrpl-up does not have a dedicated `nft buy-offer` subcommand)
+xrpl-up nft offer create --nft $NFT_ID --amount 3 --owner $MINTER --seed $BUYER2_SEED
+# → BUY_OFFER_ID
+
+# Broker (or anyone) matches both offers, keeping the price difference as commission:
+xrpl-up nft offer accept --sell-offer $OFFER_ID --buy-offer $BUY_OFFER_ID --seed $BROKER_SEED
 ```
 
 ---
@@ -167,17 +164,16 @@ xrpl-up account nfts $BUYER
 ## Full lifecycle at a glance
 
 ```bash
-# 1. Mint
-xrpl-up nft mint --taxon 1 --uri https://example.com/meta.json --transfer-fee 500
-# → NFT_ID, MINTER_SEED
+# 1. Mint (minter and buyer must already be funded via `xrpl-up faucet --network local`)
+xrpl-up nft mint --taxon 1 --uri https://example.com/meta.json --transferable --transfer-fee 500 --seed $MINTER_SEED
+# → NFT_ID
 
 # 2. List for sale
-xrpl-up nft offer create --nft $NFT_ID --amount 5 --seed $MINTER_SEED
+xrpl-up nft offer create --nft $NFT_ID --amount 5 --sell --seed $MINTER_SEED
 # → OFFER_ID
 
 # 3. Accept (buy)
-xrpl-up nft offer accept --sell-offer $OFFER_ID
-# → BUYER_SEED
+xrpl-up nft offer accept --sell-offer $OFFER_ID --seed $BUYER_SEED
 
 # 4. Burn
 xrpl-up nft burn --nft $NFT_ID --seed $BUYER_SEED

--- a/examples/simple/payment-channel.md
+++ b/examples/simple/payment-channel.md
@@ -9,7 +9,7 @@ Payment channels enable fast, low-cost, off-chain micropayments between two part
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -19,10 +19,10 @@ export XRPL_NODE=local
 ## 1. Set up sender and receiver accounts
 
 ```bash
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdSenderSeedXXX  address: rSenderXXX
 
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdReceiverSeedXXX  address: rReceiverXXX
 
 SENDER_SEED=sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX
@@ -38,52 +38,53 @@ RECEIVER=rReceiverXXXXXXXXXXXXXXXXXXXXXXXXXXX
 The sender locks XRP in the channel. The receiver can claim up to this amount over the channel's lifetime.
 
 ```bash
-# Open a 50 XRP channel with a 1-day settle delay
+# Open a 50 XRP channel with a 1-hour settle delay
 xrpl-up channel create --to $RECEIVER --amount 50 --seed $SENDER_SEED \
   --settle-delay 3600
-# ✔ Channel created
-#   channelID    ABCDEF1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   amount       50 XRP
-#   destination  rReceiverXXX...
-#   settleDelay  3600 s (1 hour)
+# Transaction: D248064691A00691899A8A11F3568F4A56FBBAB99F5DA2483A27EB63F07AC470
+# Result:      tesSUCCESS
+# Fee:         0.000012 XRP
+# Ledger:      37
+# Channel ID:  ABCDEF1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 CHANNEL_ID=ABCDEF1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-Default `--settle-delay` is 86400 seconds (1 day). This is how long the receiver has to claim after the sender requests closure.
+`--settle-delay` is required (no default) — it's how long the receiver has to submit a final claim after the sender requests closure.
 
 ---
 
 ## 3. List open channels
 
+The `Public Key` field here is what the receiver needs to verify/claim signed off-chain claims later:
+
 ```bash
 xrpl-up channel list $SENDER
-# channelID  ABCDEF1234...  amount 50 XRP  balance 0 XRP  dest rReceiverXXX...
+# Channel ID:   ABCDEF1234...
+# Amount:       50.000000 XRP
+# Balance:      0.000000 XRP
+# Destination:  rReceiverXXX...
+# Settle Delay: 3600 seconds
+# Public Key:   ED1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+PUBKEY=ED1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ---
 
 ## 4. Sign off-chain claims (sender)
 
-The sender generates signed payment authorizations off-chain — no on-chain transaction, no fee.
+The sender generates signed payment authorizations off-chain — no on-chain transaction, no fee. `channel sign` prints only the raw signature hex (nothing else) — the receiver already has the public key from step 3:
 
 ```bash
 # Authorize the receiver to claim up to 1 XRP
-xrpl-up channel sign $CHANNEL_ID 1 --seed $SENDER_SEED
-# ✔ Claim signed (off-chain)
-#   channel    ABCDEF1234...
-#   amount     1 XRP
-#   signature  3045...XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#   publicKey  ED1234...
-#
-#   Verify:  xrpl-up channel verify ABCDEF1234... 1 3045... ED1234...
-#   Claim:   xrpl-up channel claim  ABCDEF1234... --amount 1 --signature 3045... --public-key ED1234... --seed <receiver-seed>
+xrpl-up channel sign --channel $CHANNEL_ID --amount 1 --seed $SENDER_SEED
+# 3045...XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 SIG_1XRP=3045...XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-PUBKEY=ED1234XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-Send the signature and public key to the receiver out-of-band (e.g., over a WebSocket, HTTP, or message queue).
+Send the signature to the receiver out-of-band (e.g., over a WebSocket, HTTP, or message queue) — they already have the channel's public key from `channel list`.
 
 ---
 
@@ -93,11 +94,11 @@ Each new claim covers the cumulative total, not the increment. Always sign for t
 
 ```bash
 # After delivering more service, authorize up to 3 XRP total
-xrpl-up channel sign $CHANNEL_ID 3 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 3 --seed $SENDER_SEED
 # → SIG_3XRP=...
 
 # After more, authorize up to 7 XRP total
-xrpl-up channel sign $CHANNEL_ID 7 --seed $SENDER_SEED
+xrpl-up channel sign --channel $CHANNEL_ID --amount 7 --seed $SENDER_SEED
 # → SIG_7XRP=...
 ```
 
@@ -110,7 +111,7 @@ The receiver only needs to redeem the latest (highest-value) claim.
 Before accepting a claim as payment, the receiver can verify its signature:
 
 ```bash
-xrpl-up channel verify $CHANNEL_ID 7 $SIG_7XRP $PUBKEY
+xrpl-up channel verify --channel $CHANNEL_ID --amount 7 --signature $SIG_7XRP --public-key $PUBKEY
 # ✔ Claim signature valid
 ```
 
@@ -122,9 +123,13 @@ Exit code `1` if invalid — useful in automated systems.
 
 When the receiver wants to settle, they submit the best claim on-chain:
 
+`--signature` requires both `--amount` (what the signature authorizes) and `--balance` (total XRP delivered by this claim — the same value for a single claim):
+
 ```bash
-xrpl-up channel claim $CHANNEL_ID \
+xrpl-up channel claim \
+  --channel $CHANNEL_ID \
   --amount 7 \
+  --balance 7 \
   --signature $SIG_7XRP \
   --public-key $PUBKEY \
   --seed $RECEIVER_SEED
@@ -141,7 +146,7 @@ The receiver now holds 7 XRP; 43 XRP remains in the channel for future use.
 If the channel is running low, the sender can top it up:
 
 ```bash
-xrpl-up channel fund $CHANNEL_ID 20 --seed $SENDER_SEED
+xrpl-up channel fund --channel $CHANNEL_ID --amount 20 --seed $SENDER_SEED
 # ✔ Channel funded  +20 XRP  (total: 70 XRP)
 ```
 
@@ -152,14 +157,14 @@ xrpl-up channel fund $CHANNEL_ID 20 --seed $SENDER_SEED
 ### Option A: Receiver requests closure (immediate, if no pending balance)
 
 ```bash
-xrpl-up channel claim $CHANNEL_ID --close --seed $RECEIVER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $RECEIVER_SEED
 # ✔ Channel closed
 ```
 
 ### Option B: Sender requests closure (with settle delay)
 
 ```bash
-xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $SENDER_SEED
 # ✔ Close requested — receiver has 3600 s to submit final claim
 ```
 
@@ -167,7 +172,7 @@ After the settle delay passes without a receiver claim, the sender can close the
 
 ```bash
 # After settle delay expires:
-xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $SENDER_SEED
 # ✔ Channel closed  remaining 43 XRP returned to sender
 ```
 
@@ -177,23 +182,23 @@ xrpl-up channel claim $CHANNEL_ID --close --seed $SENDER_SEED
 
 ```bash
 # 1. Open channel
-xrpl-up channel create --to $RECEIVER --amount 50 --seed $SENDER_SEED
+xrpl-up channel create --to $RECEIVER --amount 50 --settle-delay 3600 --seed $SENDER_SEED
 # → CHANNEL_ID
 
 # 2. Off-chain: sign claims as service is delivered (no fee)
-xrpl-up channel sign $CHANNEL_ID 1  --seed $SENDER_SEED   # → SIG_1
-xrpl-up channel sign $CHANNEL_ID 5  --seed $SENDER_SEED   # → SIG_5
-xrpl-up channel sign $CHANNEL_ID 12 --seed $SENDER_SEED   # → SIG_12
+xrpl-up channel sign --channel $CHANNEL_ID --amount 1  --seed $SENDER_SEED   # → SIG_1
+xrpl-up channel sign --channel $CHANNEL_ID --amount 5  --seed $SENDER_SEED   # → SIG_5
+xrpl-up channel sign --channel $CHANNEL_ID --amount 12 --seed $SENDER_SEED   # → SIG_12
 
 # 3. Receiver verifies latest claim
-xrpl-up channel verify $CHANNEL_ID 12 $SIG_12 $PUBKEY
+xrpl-up channel verify --channel $CHANNEL_ID --amount 12 --signature $SIG_12 --public-key $PUBKEY
 
 # 4. On-chain settlement (once)
-xrpl-up channel claim $CHANNEL_ID --amount 12 --signature $SIG_12 \
+xrpl-up channel claim --channel $CHANNEL_ID --amount 12 --balance 12 --signature $SIG_12 \
   --public-key $PUBKEY --seed $RECEIVER_SEED
 
 # 5. Close
-xrpl-up channel claim $CHANNEL_ID --close --seed $RECEIVER_SEED
+xrpl-up channel claim --channel $CHANNEL_ID --close --seed $RECEIVER_SEED
 ```
 
 ---
@@ -206,7 +211,7 @@ xrpl-up channel claim $CHANNEL_ID --close --seed $RECEIVER_SEED
 | **Claim** | An off-chain signed authorization for the receiver to claim up to `amount` XRP. |
 | **Cumulative amount** | Each claim covers the *total* amount from channel open, not the increment. Always submit the highest claim. |
 | **Settle delay** | Grace period after the sender requests closure — gives the receiver time to submit their final claim. |
-| **Public key** | The signer's Ed25519 / SECP256k1 public key. Printed by `channel sign` and required by `channel claim`. |
+| **Public key** | The channel source's Ed25519 / SECP256k1 public key, from the channel's own ledger data (`channel list`). Required by `channel verify`/`channel claim`. |
 
 ---
 

--- a/examples/simple/tickets.md
+++ b/examples/simple/tickets.md
@@ -7,7 +7,7 @@ Tickets reserve sequence numbers, allowing you to submit transactions out-of-ord
 ## Prerequisites
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -29,26 +29,16 @@ Normally, XRPL transactions must be submitted in strict sequence order. If you n
 
 ```bash
 # Fund a wallet (or use an existing one)
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # → seed: sEdUserSeedXXX  address: rUserXXX
 
 USER_SEED=sEdUserSeedXXXXXXXXXXXXXXXXXXXXXX
 USER=rUserXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # Reserve 5 tickets
-xrpl-up ticket create 5 --seed $USER_SEED
+xrpl-up ticket create --count 5 --seed $USER_SEED
 # ✔ 5 tickets created
 #   sequences: 10, 11, 12, 13, 14
-```
-
-Or auto-fund a fresh wallet with tickets on local:
-
-```bash
-xrpl-up ticket create 3 --auto-fund
-# ✔ 3 tickets created
-#   address:   rNewWalletXXX...
-#   seed:      sEdNewSeedXXX...
-#   sequences: 4, 5, 6
 ```
 
 ---
@@ -113,7 +103,7 @@ Tickets shine in multi-sig scenarios where each signer prepares their transactio
 
 ```bash
 # 1. Reserve 3 tickets for 3 parallel transactions
-xrpl-up ticket create 3 --seed $USER_SEED
+xrpl-up ticket create --count 3 --seed $USER_SEED
 # → sequences: 20, 21, 22
 
 # 2. Signer A prepares a transaction using ticket 20

--- a/examples/simple/xrp-payment.md
+++ b/examples/simple/xrp-payment.md
@@ -9,7 +9,7 @@ Send XRP between accounts on XRPL. This is the most basic operation and a good s
 Start a local sandbox (or skip this and use `--network testnet` instead):
 
 ```bash
-xrpl-up node
+xrpl-up start --detach
 xrpl-up status   # wait until "healthy"
 export XRPL_NODE=local
 ```
@@ -20,14 +20,14 @@ export XRPL_NODE=local
 
 ```bash
 # Fund a sender wallet via the local genesis faucet
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # Output:
 #   address : rSenderXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #   seed    : sEdSenderSeedXXXXXXXXXXXXXXXXXXXXX
 #   balance : 1000 XRP
 
 # Fund a receiver wallet
-xrpl-up faucet --local
+xrpl-up faucet --network local
 # Output:
 #   address : rReceiverXXXXXXXXXXXXXXXXXXXXXXXXXX
 #   seed    : sEdReceiverSeedXXXXXXXXXXXXXXXXXXXX
@@ -46,15 +46,10 @@ RECEIVER=rReceiverXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## 2. Send XRP
 
 ```bash
-# Send 10 XRP from the sender to the receiver
-xrpl-up offer create --taker-pays 10 --taker-gets 10   # not the right command — see below
+xrpl-up payment --to $RECEIVER --amount 10 --seed $SENDER_SEED --node local
 ```
 
-Actually, XRP payments are sent with the `faucet` command for funded wallets, or directly via a script. For a direct send between two existing accounts, use:
-
-> **Note:** xrpl-up does not have a standalone `pay` subcommand for XRP — for XRP transfers between two existing accounts, use `check create` + `check cash` (deferred), or use `escrow create` + `escrow finish` for time-locked transfers, or use a script via `xrpl-up run`. For instant XRP delivery, the `faucet` command handles funding new wallets, and the DEX can swap XRP for IOUs.
-
-See [`checks.md`](checks.md) for a deferred XRP payment, [`escrow.md`](escrow.md) for time-locked XRP, or the quick-start script below.
+`payment` (alias `send`) sends one signed `Payment` transaction directly between two existing accounts. `--amount` also accepts IOU (`10/USD/rIssuer...`) and MPT amounts for non-XRP sends.
 
 ---
 
@@ -66,8 +61,8 @@ Generate a project and run the built-in payment example:
 xrpl-up init my-xrp-demo
 cd my-xrp-demo
 npm install
-npm run node          # starts local sandbox
-npm run example       # runs scripts/example-payment.ts
+npm run start                              # starts local sandbox
+xrpl-up run scripts/example-payment.ts     # runs the generated example
 ```
 
 The generated `scripts/example-payment.ts` sends 10 XRP between two auto-funded wallets and prints before/after balances.


### PR DESCRIPTION
## Summary
- Corrects all 18 example markdown files (README + 12 simple + 5 advanced) where commands no longer matched the actual CLI: renamed commands, wrong flags, positional args used where flags are required, missing required companion flags, and false "auto-funds a wallet" claims.
- One fully fictional command replaced: `xrpl-up accountset signer-list ...` → the real `xrpl-up multisig set --quorum --signer ...`.
- Every fix cross-checked against the actual `commander` option definitions in `src/cli/commands/*.ts`; several flows (payment, amm, nft, mpt, payment-channel) additionally live-verified end-to-end against a running sandbox.

## Test plan
- [x] Diffed each changed command against its `commander` definition in source
- [x] Live-verified full AMM bootstrap → create → trade flow
- [x] Live-verified NFT mint → sell offer → accept → burn, plus buy-offer creation
- [x] Live-verified MPT create → authorize → payment → lock/unlock → clawback
- [x] Live-verified payment channel create → sign → verify → claim → fund → close
- [x] Live-verified multisig set command

🤖 Generated with [Claude Code](https://claude.com/claude-code)